### PR TITLE
chore: better format

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bendsql"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "Apache-2.0"
 description = "Databend Native Command Line Tool"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -33,10 +33,14 @@ pub struct Settings {
     pub display_pretty_sql: bool,
     pub prompt: String,
     pub progress_color: String,
-    pub output_format: OutputFormat,
+
     /// Show progress [bar] when executing queries.
     /// Only works in non-interactive mode.
     pub show_progress: bool,
+
+    /// Output format is set by the flag.
+    #[serde(skip)]
+    pub output_format: OutputFormat,
 }
 
 #[derive(ValueEnum, Clone, Debug, PartialEq, Deserialize)]

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -156,6 +156,13 @@ impl Session {
                 }
             }
         }
+
+        // if the last query is not finished with `;`, we need to execute it.
+        if let Some(query) = self.query.take() {
+            if let Err(e) = self.handle_query(false, &query).await {
+                eprintln!("{}", e);
+            }
+        }
     }
 
     fn append_query(&mut self, line: &str) -> Option<String> {


### PR DESCRIPTION
changes:

1. better auto output format

TSV for non-repl mode;  Table for repl mode.

2. repspect last sql query:  


```
❯ echo "select 3,5" | ./target/release/bendsql -u sundy -p abc --port 8900 -h127.0.0.1 --flight -o csv
3,5
```