### PR TITLE
feat: add output null and time

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -43,6 +43,8 @@ pub struct Settings {
     /// Output format is set by the flag.
     #[serde(skip)]
     pub output_format: OutputFormat,
+    #[serde(skip)]
+    pub time: bool,
 }
 
 #[derive(ValueEnum, Clone, Debug, PartialEq, Deserialize)]
@@ -50,7 +52,6 @@ pub enum OutputFormat {
     Table,
     CSV,
     TSV,
-    Time,
     Null,
 }
 
@@ -67,10 +68,10 @@ impl Settings {
                     "csv" => OutputFormat::CSV,
                     "tsv" => OutputFormat::TSV,
                     "null" => OutputFormat::Null,
-                    "time" => OutputFormat::Time,
                     _ => return Err(anyhow!("Unknown output format: {}", cmd_value)),
                 }
             }
+            "time" => self.time = cmd_value.parse()?,
             _ => return Err(anyhow!("Unknown command: {}", cmd_name)),
         }
         Ok(())
@@ -117,6 +118,7 @@ impl Default for Settings {
             prompt: "{user}@{host}> ".to_string(),
             output_format: OutputFormat::Table,
             show_progress: false,
+            time: false,
         }
     }
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -50,6 +50,8 @@ pub enum OutputFormat {
     Table,
     CSV,
     TSV,
+    Time,
+    Null,
 }
 
 impl Settings {
@@ -64,6 +66,8 @@ impl Settings {
                     "table" => OutputFormat::Table,
                     "csv" => OutputFormat::CSV,
                     "tsv" => OutputFormat::TSV,
+                    "null" => OutputFormat::Null,
+                    "time" => OutputFormat::Time,
                     _ => return Err(anyhow!("Unknown output format: {}", cmd_value)),
                 }
             }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -199,10 +199,11 @@ impl<'a> ChunkDisplay for FormatDisplay<'a> {
                     wtr.write_record(record)?;
                 }
             }
-            OutputFormat::Time => {
-                println!("{:.3}", self._start.elapsed().as_secs_f64());
-            }
             OutputFormat::Null => {}
+        }
+
+        if self.settings.time {
+            eprintln!("{:.3}", self._start.elapsed().as_secs_f64());
         }
         Ok(())
     }

--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -199,6 +199,10 @@ impl<'a> ChunkDisplay for FormatDisplay<'a> {
                     wtr.write_record(record)?;
                 }
             }
+            OutputFormat::Time => {
+                println!("{:.3}", self._start.elapsed().as_secs_f64());
+            }
+            OutputFormat::Null => {}
         }
         Ok(())
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -136,6 +136,9 @@ struct Args {
 
     #[clap(long, help = "Show progress for data loading in stderr")]
     progress: bool,
+
+    #[clap(long, help = "Only show execution time without results")]
+    time: bool,
 }
 
 /// Parse a single key-value pair
@@ -247,6 +250,10 @@ pub async fn main() -> Result<()> {
         config.settings.output_format = OutputFormat::Table;
     } else {
         config.settings.output_format = OutputFormat::TSV;
+    }
+
+    if args.time {
+        config.settings.output_format = OutputFormat::Time;
     }
 
     let mut session = session::Session::try_new(dsn, config.settings, is_repl).await?;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -251,10 +251,7 @@ pub async fn main() -> Result<()> {
     } else {
         config.settings.output_format = OutputFormat::TSV;
     }
-
-    if args.time {
-        config.settings.output_format = OutputFormat::Time;
-    }
+    config.settings.time = args.time;
 
     let mut session = session::Session::try_new(dsn, config.settings, is_repl).await?;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,7 +20,7 @@ mod display;
 mod helper;
 mod session;
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, io::stdin};
 
 use anyhow::{anyhow, Result};
 use clap::{CommandFactory, Parser, ValueEnum};
@@ -268,13 +268,11 @@ pub async fn main() -> Result<()> {
             if args.non_interactive {
                 return Err(anyhow!("no query specified"));
             }
-            session.handle_stdin().await
+            session.handle_reader(stdin().lock()).await
         }
         Some(query) => match args.data {
             None => {
-                if let Err(e) = session.handle_query(false, &query).await {
-                    eprintln!("{}", e);
-                }
+                session.handle_reader(std::io::Cursor::new(query)).await;
             }
             Some(data) => {
                 let options = args.format.get_options(&args.format_opt);

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::io::stdin;
 use std::io::BufRead;
 use std::path::Path;
 use std::sync::Arc;
@@ -71,7 +72,7 @@ impl Session {
         if self.is_repl {
             self.handle_repl().await;
         } else {
-            self.handle_stdin().await;
+            self.handle_reader(stdin().lock()).await;
         }
     }
 
@@ -144,8 +145,8 @@ impl Session {
         let _ = rl.save_history(&get_history_path());
     }
 
-    pub async fn handle_stdin(&mut self) {
-        let mut lines = std::io::stdin().lock().lines();
+    pub async fn handle_reader<R: BufRead>(&mut self, r: R) {
+        let mut lines = r.lines();
         while let Some(Ok(line)) = lines.next() {
             let queries = self.append_query(&line);
             for query in queries {
@@ -166,7 +167,7 @@ impl Session {
         }
     }
 
-    fn append_query(&mut self, line: &str) -> Vec<String> {
+    pub fn append_query(&mut self, line: &str) -> Vec<String> {
         let line = line.trim();
         if line.is_empty() {
             return vec![];


### PR DESCRIPTION
simple way to measure performance:

```
❯ bendsql --time  --query "select sum(number) from numbers(10000000000)"
0.271
```