### PR TITLE
feat: support config max_display_rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,93 @@ sudo apt install bendsql
 * Binary: check for latest release [here](https://github.com/datafuselabs/databend-client/releases)
 
 
+## Usage
+
+```
+❯ bendsql --help
+Databend Native Command Line Tool
+
+Usage: bendsql [OPTIONS]
+
+Options:
+      --help                     Print help information
+      --flight                   Using flight sql protocol
+      --tls                      Enable TLS
+  -h, --host <HOST>              Databend Server host, Default: 127.0.0.1
+  -P, --port <PORT>              Databend Server port, Default: 8000
+  -u, --user <USER>              Default: root
+  -p, --password <PASSWORD>      [env: BENDSQL_PASSWORD=]
+  -D, --database <DATABASE>      Database name
+      --set <SET>                Settings
+      --dsn <DSN>                Data source name [env: BENDSQL_DSN=]
+  -n, --non-interactive          Force non-interactive mode
+  -q, --query <QUERY>            Query to execute
+  -d, --data <DATA>              Data to load, @file or @- for stdin
+  -f, --format <FORMAT>          Data format to load [default: csv] [possible values: csv, tsv, ndjson, parquet, xml]
+      --format-opt <FORMAT_OPT>  Data format options
+  -o, --output <OUTPUT>          Output format [possible values: table, csv, tsv, null]
+      --progress                 Show progress for query execution in stderr, only works with output format `table` and `null`.
+      --stats                    Show stats after query execution in stderr, only works with non-interactive mode.
+      --time                     Only show execution time without results, will implicitly set output format to `null`.
+  -V, --version                  Print version
+```
+
+## Custom configuration
+
+By default bendsql will read configuration from `~/.config/bendsql/config.toml` if the file exists.
+
+- Example file
+```
+❯ cat ~/.config/bendsql/config.toml
+[connection]
+connect_timeout = "30s"
+
+
+[settings]
+display_pretty_sql = true
+progress_color = "green"
+prompt = ":) "
+
+```
+
+
+- Connection section
+
+| Parameter | Description |
+|---|---|
+| `host` | Server host to connect. |
+| `port` | Server port to connect. |
+| `user` | User name. |
+| `database` | Which database to connect. |
+| `args` | Additional connection args. |
+
+
+- Settings section
+
+| Parameter | Description |
+|---|---|
+| `display_pretty_sql` | Whether to display SQL queries in a formatted way. |
+| `prompt` | The prompt to display before asking for input. |
+| `progress_color` | The color to use for the progress bar. |
+| `show_progress` | Whether to show a progress bar when executing queries. |
+| `show_stats` | Whether to show statistics after executing queries. |
+| `max_display_rows` | The maximum number of rows to display in table output format. |
+| `output_format` | The output format to use. |
+| `time` | Whether to show the time elapsed when executing queries. |
+| `multi_line` | Whether to allow multi-line input. |
+
+
+## Control commands in REPL
+
+We can use `.CMD_NAME VAL` to update the `Settings` above in runtime, example:
+```
+❯ bendsql
+
+:) .display_pretty_sql false
+:) .max_display_rows 10
+```
+
+
 ## Development
 
 ### Cargo fmt, clippy, audit

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -52,7 +52,7 @@ pub struct Settings {
     /// Show stats after executing queries.
     /// Only works with non-interactive mode.
     pub show_stats: bool,
-
+    pub max_display_rows: usize,
     /// Output format is set by the flag.
     pub output_format: OutputFormat,
 
@@ -109,6 +109,7 @@ impl Settings {
             }
             "time" => self.time = cmd_value.parse()?,
             "multi_line" => self.multi_line = cmd_value.parse()?,
+            "max_display_rows" => self.max_display_rows = cmd_value.parse()?,
             _ => return Err(anyhow!("Unknown command: {}", cmd_name)),
         }
         Ok(())
@@ -155,6 +156,7 @@ impl Default for Settings {
             prompt: "{user}@{host}> ".to_string(),
             output_format: OutputFormat::Table,
             show_progress: false,
+            max_display_rows: 40,
             show_stats: false,
             time: false,
             multi_line: true,

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -52,6 +52,7 @@ pub struct Settings {
     /// Show stats after executing queries.
     /// Only works with non-interactive mode.
     pub show_stats: bool,
+    /// Output max rows (only works in table output format)
     pub max_display_rows: usize,
     /// Output format is set by the flag.
     pub output_format: OutputFormat,


### PR DESCRIPTION

default `max_display_rows` is 40

```

:) .max_display_rows 10
:) select 1, 'a', number, 2 from numbers(1000);

SELECT
  1,
  'a',
  number,
  2
FROM
  numbers(1000)

┌──────────────────────────────────────┐
│      1     │   'a'  │ number │   2   │
│    UInt8   │ String │ UInt64 │ UInt8 │
├────────────┼────────┼────────┼───────┤
│          1 │ a      │      0 │     2 │
│          1 │ a      │      1 │     2 │
│          1 │ a      │      2 │     2 │
│          1 │ a      │      3 │     2 │
│          1 │ a      │      4 │     2 │
│          · │ ·      │      · │     · │
│          · │ ·      │      · │     · │
│          · │ ·      │      · │     · │
│          1 │ a      │    995 │     2 │
│          1 │ a      │    996 │     2 │
│          1 │ a      │    997 │     2 │
│          1 │ a      │    998 │     2 │
│          1 │ a      │    999 │     2 │
│  1000 rows │        │        │       │
│ (10 shown) │        │        │       │
└──────────────────────────────────────┘
1000 rows in 0.057 sec. Processed 1 thousand rows, 1000B (17.44 thousand rows/s, 136.27 KiB/s)

:) 
```