### PR TITLE
fix(cli): fix paste sql with newline

### DIFF
--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -232,8 +232,12 @@ impl Session {
                 TokenKind::Comment => {
                     in_comment = true;
                 }
-                TokenKind::Newline | TokenKind::EOI => {
+                TokenKind::EOI => {
                     in_comment = false;
+                }
+                TokenKind::Newline => {
+                    in_comment = false;
+                    self.query.push(' ');
                 }
                 TokenKind::CommentBlockStart | TokenKind::CommentBlockEnd => {
                     unreachable!("Comment block should be handled before")


### PR DESCRIPTION
Fix paste SQL into cli with newline.
```
select
1
from numbers(3);
```