### PR TITLE
feat: support get/put stmt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
@@ -20,7 +20,7 @@ keywords = ["databend", "database"]
 repository = "https://github.com/datafuselabs/bendsql"
 
 [workspace.dependencies]
-databend-client = { path = "core", version = "0.6.2" }
-databend-driver = { path = "driver", version = "0.6.2" }
-databend-driver-macros = { path = "macros", version = "0.6.2" }
-databend-sql = { path = "sql", version = "0.6.2" }
+databend-client = { path = "core", version = "0.6.3" }
+databend-driver = { path = "driver", version = "0.6.3" }
+databend-driver-macros = { path = "macros", version = "0.6.3" }
+databend-sql = { path = "sql", version = "0.6.3" }

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-arm64",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-x64",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-x64-gnu",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-win32-x64-msvc",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "os": [
     "win32"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "databend-driver",
   "author": "Databend Authors <opensource@datafuselabs.com>",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",

--- a/cli/README.md
+++ b/cli/README.md
@@ -90,6 +90,13 @@ Bye
 2
 ```
 
+### Put local files into stage
+
+```
+create stage s_temp;
+put fs:///tmp/a*.txt @s_temp/abc;
+```
+
 ## Features
 
 - basic keywords highlight

--- a/cli/src/ast/mod.rs
+++ b/cli/src/ast/mod.rs
@@ -17,7 +17,13 @@ mod tokenizer;
 use sqlformat::{Indent, QueryParams};
 pub use tokenizer::*;
 
+use crate::session::QueryKind;
+
 pub fn format_query(query: &str) -> String {
+    let kind = QueryKind::from(query);
+    if kind == QueryKind::Put {
+        return query.to_owned();
+    }
     let options = sqlformat::FormatOptions {
         indent: Indent::Spaces(2),
         uppercase: true,

--- a/cli/src/ast/mod.rs
+++ b/cli/src/ast/mod.rs
@@ -21,7 +21,7 @@ use crate::session::QueryKind;
 
 pub fn format_query(query: &str) -> String {
     let kind = QueryKind::from(query);
-    if kind == QueryKind::Put {
+    if kind == QueryKind::Put || kind == QueryKind::Get {
         return query.to_owned();
     }
     let options = sqlformat::FormatOptions {

--- a/cli/src/ast/tokenizer.rs
+++ b/cli/src/ast/tokenizer.rs
@@ -634,6 +634,8 @@ pub enum TokenKind {
     PROCESSLIST,
     #[token("PURGE", ignore(ascii_case))]
     PURGE,
+    #[token("PUT", ignore(ascii_case))]
+    PUT,
     #[token("QUARTER", ignore(ascii_case))]
     QUARTER,
     #[token("QUERY", ignore(ascii_case))]

--- a/cli/src/ast/tokenizer.rs
+++ b/cli/src/ast/tokenizer.rs
@@ -476,6 +476,8 @@ pub enum TokenKind {
     TABLE_FUNCTIONS,
     #[token("FUSE", ignore(ascii_case))]
     FUSE,
+    #[token("GET", ignore(ascii_case))]
+    GET,
     #[token("GLOBAL", ignore(ascii_case))]
     GLOBAL,
     #[token("GRAPH", ignore(ascii_case))]

--- a/cli/tests/http/04-put.result
+++ b/cli/tests/http/04-put.result
@@ -1,2 +1,4 @@
 /tmp/a1.txt	SUCCESS
 /tmp/a2.txt	SUCCESS
+/tmp/edf/abc/a1.txt	SUCCESS
+/tmp/edf/abc/a2.txt	SUCCESS

--- a/cli/tests/http/04-put.result
+++ b/cli/tests/http/04-put.result
@@ -1,4 +1,4 @@
 /tmp/a1.txt	SUCCESS
 /tmp/a2.txt	SUCCESS
-/tmp/edf/abc/a1.txt	SUCCESS
-/tmp/edf/abc/a2.txt	SUCCESS
+/tmp/edf/a1.txt	SUCCESS
+/tmp/edf/a2.txt	SUCCESS

--- a/cli/tests/http/04-put.result
+++ b/cli/tests/http/04-put.result
@@ -1,0 +1,2 @@
+/tmp/a1.txt	SUCCESS
+/tmp/a2.txt	SUCCESS

--- a/cli/tests/http/04-put.sh
+++ b/cli/tests/http/04-put.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo "CREATE STAGE s_temp" | ${BENDSQL}
+
+echo "ABCD" > /tmp/a1.txt
+echo "ABCD" > /tmp/a2.txt
+
+echo 'put fs:///tmp/a*.txt @s_temp/abc' | ${BENDSQL}

--- a/cli/tests/http/04-put.sh
+++ b/cli/tests/http/04-put.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-echo "CREATE STAGE s_temp" | ${BENDSQL}
+echo "CREATE STAGE ss_temp" | ${BENDSQL}
 
 echo "ABCD" > /tmp/a1.txt
 echo "ABCD" > /tmp/a2.txt
 
-echo 'put fs:///tmp/a*.txt @s_temp/abc' | ${BENDSQL}
+echo 'put fs:///tmp/a*.txt @ss_temp/abc' | ${BENDSQL}
+echo 'get @ss_temp/abc fs:///tmp/edf' | ${BENDSQL}

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -437,7 +437,7 @@ impl APIClient {
         }
     }
 
-    async fn upload_to_stage_with_stream(
+    pub async fn upload_to_stage_with_stream(
         &self,
         stage_location: &str,
         data: impl AsyncRead + Send + Sync + 'static,

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -80,7 +80,7 @@ impl TryFrom<&str> for StageLocation {
 
 #[derive(Clone)]
 pub struct APIClient {
-    cli: HttpClient,
+    pub cli: HttpClient,
     endpoint: Url,
     pub host: String,
     pub port: u16,

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -33,6 +33,8 @@ databend-sql = { workspace = true }
 async-trait = "0.1.68"
 chrono = { version = "0.4.26", default-features = false, features = ["clock"] }
 dyn-clone = "1.0.11"
+futures = "0.3.28"
+glob = "0.3.1"
 http = "0.2.9"
 percent-encoding = "2.3.0"
 serde = { version = "1.0.164", default-features = false, features = ["derive"] }

--- a/driver/src/conn.rs
+++ b/driver/src/conn.rs
@@ -107,5 +107,15 @@ pub trait Connection: DynClone + Send + Sync {
             "PUT statement only available in HTTP API".to_owned(),
         ))
     }
+
+    async fn get_files(
+        &self,
+        _stage_path: &str,
+        _local_file: &str,
+    ) -> Result<(Schema, RowProgressIterator)> {
+        Err(Error::IO(
+            "GET statement only available in HTTP API".to_owned(),
+        ))
+    }
 }
 dyn_clone::clone_trait_object!(Connection);

--- a/driver/src/conn.rs
+++ b/driver/src/conn.rs
@@ -97,5 +97,15 @@ pub trait Connection: DynClone + Send + Sync {
         file_format_options: Option<BTreeMap<&str, &str>>,
         copy_options: Option<BTreeMap<&str, &str>>,
     ) -> Result<QueryProgress>;
+
+    async fn put_files(
+        &self,
+        _local_file: &str,
+        _stage_path: &str,
+    ) -> Result<(Schema, RowProgressIterator)> {
+        Err(Error::IO(
+            "PUT statement only available in HTTP API".to_owned(),
+        ))
+    }
 }
 dyn_clone::clone_trait_object!(Connection);

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -174,7 +174,7 @@ impl Connection for RestAPIConnection {
 
         let mut stage_location = stage_location.to_owned();
         if !stage_location.ends_with('/') {
-            stage_location.push_str('/');
+            stage_location.push('/');
         }
 
         let list_sql = format!("list {stage_location}");

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -174,7 +174,7 @@ impl Connection for RestAPIConnection {
 
         let mut stage_location = stage_location.to_owned();
         if !stage_location.ends_with('/') {
-            stage_location.push_str("/");
+            stage_location.push_str('/');
         }
 
         let list_sql = format!("list {stage_location}");

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -196,8 +196,8 @@ impl Connection for RestAPIConnection {
             while let Some(r) = resp.next().await {
                 let (_, headers, url): (String, String, String) = r.unwrap().try_into().unwrap();
 
-                if name.starts_with(&stage_path) {
-                    name = name[stage_path.len() + 1..].to_string();
+                if !stage_path.is_empty() && name.starts_with(&stage_path) {
+                    name = name[stage_path.len()..].to_string();
                 }
 
                 let headers: BTreeMap<String, String> = serde_json::from_str(&headers)?;

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -162,6 +162,16 @@ impl Connection for RestAPIConnection {
         stage_location: &str,
         local_file: &str,
     ) -> Result<(Schema, RowProgressIterator)> {
+        let dsn = url::Url::parse(local_file)?;
+        let schema = dsn.scheme();
+        if schema != "file" && schema != "fs" {
+            return Err(Error::BadArgument(
+                "Only support schema file:// or fs://".to_string(),
+            ));
+        }
+
+        let local_file = dsn.path();
+
         let mut stage_location = stage_location.to_owned();
         if !stage_location.ends_with('/') {
             stage_location.push_str("/");

--- a/sql/Cargo.toml
+++ b/sql/Cargo.toml
@@ -28,6 +28,7 @@ arrow-array = { version = "41.0.0", optional = true }
 arrow-cast = { version = "41.0.0", features = ["prettyprint"], optional = true }
 arrow-flight = { version = "41.0.0", features = ["flight-sql-experimental"], optional = true }
 arrow-schema = { version = "41.0.0", optional = true }
+glob = "0.3.1"
 tonic = { version = "0.9.2", default-features = false, features = [
     "transport",
     "codegen",

--- a/sql/src/error.rs
+++ b/sql/src/error.rs
@@ -124,6 +124,18 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<glob::GlobError> for Error {
+    fn from(e: glob::GlobError) -> Self {
+        Error::IO(e.to_string())
+    }
+}
+
+impl From<glob::PatternError> for Error {
+    fn from(e: glob::PatternError) -> Self {
+        Error::Parsing(e.to_string())
+    }
+}
+
 #[cfg(feature = "flight-sql")]
 impl From<tonic::Status> for Error {
     fn from(e: tonic::Status) -> Self {

--- a/sql/src/rows.rs
+++ b/sql/src/rows.rs
@@ -106,6 +106,10 @@ impl Row {
     pub fn values(&self) -> &[Value] {
         &self.0
     }
+
+    pub fn from_vec(values: Vec<Value>) -> Self {
+        Self(values)
+    }
 }
 
 impl IntoIterator for Row {

--- a/sql/src/schema.rs
+++ b/sql/src/schema.rs
@@ -144,6 +144,10 @@ impl Schema {
     pub fn fields(&self) -> &[Field] {
         &self.0
     }
+
+    pub fn from_vec(fields: Vec<Field>) -> Self {
+        Self(fields)
+    }
 }
 
 impl TryFrom<&TypeDesc<'_>> for DataType {


### PR DESCRIPTION
refer to snowflake's get/put stmt: https://docs.snowflake.com/en/sql-reference/sql/get


syntax: `PUT file://<path_to_file>/<filename> internalStage` and `GET internalStage file://<path_to_file>`


```
🐳 @default:) put fs:///Users/sundy/*.sh   @s4/abc;

put fs:///Users/sundy/*.sh   @s4/abc

┌────────────────────────────────────────────┐
│               file               │  status │
│              String              │  String │
├──────────────────────────────────┼─────────┤
│ /Users/sundy/databend_all_ssb.sh │ SUCCESS │
│ /Users/sundy/fetch.sh            │ SUCCESS │
│ /Users/sundy/rustup-init.sh      │ SUCCESS │
│ /Users/sundy/source_fs.sh        │ SUCCESS │
│ /Users/sundy/source_minio.sh     │ SUCCESS │
│ /Users/sundy/source_s3.sh        │ SUCCESS │
│ /Users/sundy/start.sh            │ SUCCESS │
└────────────────────────────────────────────┘
🐳 @default:) get @s4/abc/ fs:///tmp/edf;

get @s4/abc/ fs:///tmp/edf

┌───────────────────────────────────────┐
│             file            │  status │
│            String           │  String │
├─────────────────────────────┼─────────┤
│ /tmp/edf/databend_all_ssb.sh │ SUCCESS │
│ /tmp/edf/fetch.sh            │ SUCCESS │
│ /tmp/edf/rustup-init.sh      │ SUCCESS │
│ /tmp/edf/source_fs.sh        │ SUCCESS │
│ /tmp/edf/source_minio.sh     │ SUCCESS │
│ /tmp/edf/source_s3.sh        │ SUCCESS │
│ /tmp/edf/start.sh            │ SUCCESS │
└───────────────────────────────────────┘
🐳 @default:) 
```

closes  #135