### PR TITLE
chore: update anyhow to 1.0.75.

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 [dependencies]
 databend-driver = { workspace = true, features = ["rustls", "flight-sql"] }
 
-anyhow = "1.0.71"
+anyhow = "1.0.75"
 async-trait = "0.1.68"
 chrono = { version = "0.4.26", default-features = false, features = ["clock"] }
 clap = { version = "4.3.4", features = ["derive", "env"] }


### PR DESCRIPTION
Update backtrace support to nightly's new Error::provide API (rust-lang/rust#113464, #319)

https://github.com/dtolnay/anyhow/releases/tag/1.0.73