### PR TITLE
feat(cli): support expaneded display for table format

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -41,6 +41,23 @@ pub struct SettingsConfig {
 }
 
 #[derive(Clone, Debug)]
+pub enum ExpandMode {
+    On,
+    Off,
+    Auto,
+}
+
+impl From<&str> for ExpandMode {
+    fn from(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "on" => ExpandMode::On,
+            "off" => ExpandMode::Off,
+            _ => ExpandMode::Auto,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct Settings {
     pub display_pretty_sql: bool,
     pub prompt: String,
@@ -61,6 +78,9 @@ pub struct Settings {
     pub max_width: usize,
     /// Output format is set by the flag.
     pub output_format: OutputFormat,
+    /// Expand table format display, default is auto, could be on/off/auto.
+    /// only works with output format `table`.
+    pub expand: ExpandMode,
 
     /// Show time elapsed when executing queries.
     /// only works with output format `null`.
@@ -118,6 +138,7 @@ impl Settings {
                     _ => return Err(anyhow!("Unknown output format: {}", cmd_value)),
                 }
             }
+            "expand" => self.expand = cmd_value.into(),
             "time" => self.time = cmd_value.parse()?,
             "multi_line" => self.multi_line = cmd_value.parse()?,
             "max_display_rows" => self.max_display_rows = cmd_value.parse()?,
@@ -169,6 +190,7 @@ impl Default for Settings {
             progress_color: "cyan".to_string(),
             prompt: "{user}@{warehouse}/{database}> ".to_string(),
             output_format: OutputFormat::Table,
+            expand: ExpandMode::Auto,
             show_progress: false,
             max_display_rows: 40,
             max_col_width: 1024 * 1024,


### PR DESCRIPTION
* Closes: https://github.com/datafuselabs/bendsql/issues/74

```
everpcpc@(system)/tpch_10> .expand auto
everpcpc@(system)/tpch_10> select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment from part, supplier, partsupp, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%BRASS' and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' and ps_supplycost = ( select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' ) order by s_acctbal desc, n_name, s_name, p_partkey limit 1;
-[ RECORD 1 ]-----------------------------------
s_acctbal: 9994.37
   s_name: Supplier#000030084
   n_name: GERMANY
p_partkey: 380077
   p_mfgr: Manufacturer#5
s_address: Lpmw8Ht4rC,xjMQ0p50CkyG7764
  s_phone: 17-519-171-6883
s_comment: thely express instructions. regular hockey players was furiously. quickly pendi

1 row read in 1.727 sec. Processed 18.2 million row, 626.03 MiB (10.54 million row/s, 362.49 MiB/s)

everpcpc@(system)/tpch_10> select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment from part, supplier, partsupp, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%BRASS' and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' and ps_supplycost = ( select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' ) order by s_acctbal desc, n_name, s_name, p_partkey limit 2;
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    s_acctbal   │       s_name       │  n_name │ p_partkey │     p_mfgr     │          s_address          │     s_phone     │                                      s_comment                                      │
│ Decimal(15, 2) │       String       │  String │   Int64   │     String     │            String           │      String     │                                        String                                       │
├────────────────┼────────────────────┼─────────┼───────────┼────────────────┼─────────────────────────────┼─────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ 9994.37        │ Supplier#000030084 │ GERMANY │    380077 │ Manufacturer#5 │ Lpmw8Ht4rC,xjMQ0p50CkyG7764 │ 17-519-171-6883 │ thely express instructions. regular hockey players was furiously. quickly pendi     │
│ 9992.54        │ Supplier#000099650 │ RUSSIA  │    824625 │ Manufacturer#3 │ u8irlfFJRKkGmndVKa4LY       │ 32-971-481-2533 │ ironic ideas. special, ironic requests nag blithely. ironic deposits use furiously  │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
2 rows read in 1.217 sec. Processed 18.2 million rows, 626.03 MiB (14.95 million rows/s, 514.20 MiB/s)

everpcpc@(system)/tpch_10> explain select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment from part, supplier, partsupp, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%BRASS' and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' and ps_supplycost = ( select min(ps_supplycost) from partsupp, supplier, nation, region where p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' ) order by s_acctbal desc, n_name, s_name, p_partkey limit 2;
-[ EXPLAIN ]-----------------------------------
Limit
├── output columns: [part.p_mfgr (#2), part.p_partkey (#0), supplier.s_name (#10), supplier.s_address (#11), supplier.s_phone (#13), supplier.s_acctbal (#14), supplier.s_comment (#15), nation.n_name (#22)]
├── limit: 2
├── offset: 0
├── estimated rows: 2.00
└── Sort
    ├── output columns: [part.p_mfgr (#2), part.p_partkey (#0), supplier.s_name (#10), supplier.s_address (#11), supplier.s_phone (#13), supplier.s_acctbal (#14), supplier.s_comment (#15), nation.n_name (#22)]
    ├── sort keys: [s_acctbal DESC NULLS LAST, n_name ASC NULLS LAST, s_name ASC NULLS LAST, p_partkey ASC NULLS LAST]
    ├── estimated rows: 6400.00
    └── Filter
        ├── output columns: [part.p_mfgr (#2), part.p_partkey (#0), supplier.s_name (#10), supplier.s_address (#11), supplier.s_phone (#13), supplier.s_acctbal (#14), supplier.s_comment (#15), nation.n_name (#22)]
        ├── filters: [is_true(CAST(partsupp.ps_supplycost (#19) AS Decimal(15, 2) NULL) = scalar_subquery_48 (#48))]
        ├── estimated rows: 6400.00
        └── HashJoin
            ├── output columns: [min(ps_supplycost) (#48), partsupp.ps_supplycost (#19), part.p_mfgr (#2), part.p_partkey (#0), supplier.s_name (#10), supplier.s_address (#11), supplier.s_phone (#13), supplier.s_acctbal (#14), supplier.s_comment (#15), nation.n_name (#22)]
            ├── join type: RIGHT SINGLE
            ├── build keys: [CAST(p_partkey (#0) AS Int64 NULL)]
            ├── probe keys: [ps_partkey (#28)]
            ├── filters: []
            ├── estimated rows: 32000.00
            ├── HashJoin(Build)
            │   ├── output columns: [partsupp.ps_supplycost (#19), part.p_mfgr (#2), part.p_partkey (#0), supplier.s_name (#10), supplier.s_address (#11), supplier.s_phone (#13), supplier.s_acctbal (#14), supplier.s_comment (#15), nation.n_name (#22)]
            │   ├── join type: INNER
            │   ├── build keys: [supplier.s_suppkey (#9)]
            │   ├── probe keys: [partsupp.ps_suppkey (#17)]
            │   ├── filters: []
            │   ├── estimated rows: 32000.00
            │   ├── HashJoin(Build)
            │   │   ├── output columns: [supplier.s_suppkey (#9), supplier.s_name (#10), supplier.s_address (#11), supplier.s_phone (#13), supplier.s_acctbal (#14), supplier.s_comment (#15), nation.n_name (#22)]
            │   │   ├── join type: INNER
            │   │   ├── build keys: [nation.n_nationkey (#21)]
            │   │   ├── probe keys: [supplier.s_nationkey (#12)]
            │   │   ├── filters: []
            │   │   ├── estimated rows: 20000.00
            │   │   ├── HashJoin(Build)
            │   │   │   ├── output columns: [nation.n_nationkey (#21), nation.n_name (#22)]
            │   │   │   ├── join type: INNER
            │   │   │   ├── build keys: [region.r_regionkey (#25)]
            │   │   │   ├── probe keys: [nation.n_regionkey (#23)]
            │   │   │   ├── filters: []
            │   │   │   ├── estimated rows: 5.00
            │   │   │   ├── Filter(Build)
            │   │   │   │   ├── output columns: [region.r_regionkey (#25)]
            │   │   │   │   ├── filters: [region.r_name (#26) = 'EUROPE']
            │   │   │   │   ├── estimated rows: 1.00
            │   │   │   │   └── TableScan
            │   │   │   │       ├── table: default.tpch_10.region
            │   │   │   │       ├── output columns: [r_regionkey (#25), r_name (#26)]
            │   │   │   │       ├── read rows: 5
            │   │   │   │       ├── read bytes: 136
            │   │   │   │       ├── partitions total: 1
            │   │   │   │       ├── partitions scanned: 1
            │   │   │   │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
            │   │   │   │       ├── push downs: [filters: [region.r_name (#26) = 'EUROPE'], limit: NONE]
            │   │   │   │       └── estimated rows: 5.00
            │   │   │   └── TableScan(Probe)
            │   │   │       ├── table: default.tpch_10.nation
            │   │   │       ├── output columns: [n_nationkey (#21), n_name (#22), n_regionkey (#23)]
            │   │   │       ├── read rows: 25
            │   │   │       ├── read bytes: 358
            │   │   │       ├── partitions total: 1
            │   │   │       ├── partitions scanned: 1
            │   │   │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
            │   │   │       ├── push downs: [filters: [], limit: NONE]
            │   │   │       └── estimated rows: 25.00
            │   │   └── TableScan(Probe)
            │   │       ├── table: default.tpch_10.supplier
            │   │       ├── output columns: [s_suppkey (#9), s_name (#10), s_address (#11), s_nationkey (#12), s_phone (#13), s_acctbal (#14), s_comment (#15)]
            │   │       ├── read rows: 100000
            │   │       ├── read bytes: 5159158
            │   │       ├── partitions total: 1
            │   │       ├── partitions scanned: 1
            │   │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
            │   │       ├── push downs: [filters: [], limit: NONE]
            │   │       └── estimated rows: 100000.00
            │   └── HashJoin(Probe)
            │       ├── output columns: [partsupp.ps_suppkey (#17), partsupp.ps_supplycost (#19), part.p_mfgr (#2), part.p_partkey (#0)]
            │       ├── join type: INNER
            │       ├── build keys: [part.p_partkey (#0)]
            │       ├── probe keys: [partsupp.ps_partkey (#16)]
            │       ├── filters: []
            │       ├── estimated rows: 160000.00
            │       ├── Filter(Build)
            │       │   ├── output columns: [part.p_partkey (#0), part.p_mfgr (#2)]
            │       │   ├── filters: [part.p_size (#5) = 15, like(part.p_type (#4), '%BRASS')]
            │       │   ├── estimated rows: 40000.00
            │       │   └── TableScan
            │       │       ├── table: default.tpch_10.part
            │       │       ├── output columns: [p_partkey (#0), p_mfgr (#2), p_type (#4), p_size (#5)]
            │       │       ├── read rows: 2000000
            │       │       ├── read bytes: 12541510
            │       │       ├── partitions total: 3
            │       │       ├── partitions scanned: 3
            │       │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 3 to 3, bloom pruning: 3 to 3>]
            │       │       ├── push downs: [filters: [and_filters(CAST(part.p_size (#5) = 15 AS Boolean NULL), CAST(like(part.p_type (#4), '%BRASS') AS Boolean NULL))], limit: NONE]
            │       │       └── estimated rows: 2000000.00
            │       └── TableScan(Probe)
            │           ├── table: default.tpch_10.partsupp
            │           ├── output columns: [ps_partkey (#16), ps_suppkey (#17), ps_supplycost (#19)]
            │           ├── read rows: 8000000
            │           ├── read bytes: 37277453
            │           ├── partitions total: 12
            │           ├── partitions scanned: 12
            │           ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 12 to 12, bloom pruning: 0 to 0>]
            │           ├── push downs: [filters: [], limit: NONE]
            │           └── estimated rows: 8000000.00
            └── EvalScalar(Probe)
                ├── output columns: [partsupp.ps_partkey (#28), min(ps_supplycost) (#48)]
                ├── expressions: [min(ps_supplycost) (#47)]
                ├── estimated rows: 1600000.00
                └── AggregateFinal
                    ├── output columns: [min(ps_supplycost) (#47), partsupp.ps_partkey (#28)]
                    ├── group by: [ps_partkey]
                    ├── aggregate functions: [min(ps_supplycost)]
                    ├── estimated rows: 1600000.00
                    └── AggregatePartial
                        ├── output columns: [min(ps_supplycost) (#47), #_group_by_key]
                        ├── group by: [ps_partkey]
                        ├── aggregate functions: [min(ps_supplycost)]
                        ├── estimated rows: 1600000.00
                        └── HashJoin
                            ├── output columns: [partsupp.ps_partkey (#28), partsupp.ps_supplycost (#31)]
                            ├── join type: INNER
                            ├── build keys: [supplier.s_suppkey (#33)]
                            ├── probe keys: [partsupp.ps_suppkey (#29)]
                            ├── filters: []
                            ├── estimated rows: 1600000.00
                            ├── HashJoin(Build)
                            │   ├── output columns: [supplier.s_suppkey (#33)]
                            │   ├── join type: INNER
                            │   ├── build keys: [nation.n_nationkey (#40)]
                            │   ├── probe keys: [supplier.s_nationkey (#36)]
                            │   ├── filters: []
                            │   ├── estimated rows: 20000.00
                            │   ├── HashJoin(Build)
                            │   │   ├── output columns: [nation.n_nationkey (#40)]
                            │   │   ├── join type: INNER
                            │   │   ├── build keys: [region.r_regionkey (#44)]
                            │   │   ├── probe keys: [nation.n_regionkey (#42)]
                            │   │   ├── filters: []
                            │   │   ├── estimated rows: 5.00
                            │   │   ├── Filter(Build)
                            │   │   │   ├── output columns: [region.r_regionkey (#44)]
                            │   │   │   ├── filters: [region.r_name (#45) = 'EUROPE']
                            │   │   │   ├── estimated rows: 1.00
                            │   │   │   └── TableScan
                            │   │   │       ├── table: default.tpch_10.region
                            │   │   │       ├── output columns: [r_regionkey (#44), r_name (#45)]
                            │   │   │       ├── read rows: 5
                            │   │   │       ├── read bytes: 136
                            │   │   │       ├── partitions total: 1
                            │   │   │       ├── partitions scanned: 1
                            │   │   │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 1 to 1>]
                            │   │   │       ├── push downs: [filters: [region.r_name (#45) = 'EUROPE'], limit: NONE]
                            │   │   │       └── estimated rows: 5.00
                            │   │   └── TableScan(Probe)
                            │   │       ├── table: default.tpch_10.nation
                            │   │       ├── output columns: [n_nationkey (#40), n_regionkey (#42)]
                            │   │       ├── read rows: 25
                            │   │       ├── read bytes: 148
                            │   │       ├── partitions total: 1
                            │   │       ├── partitions scanned: 1
                            │   │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
                            │   │       ├── push downs: [filters: [], limit: NONE]
                            │   │       └── estimated rows: 25.00
                            │   └── TableScan(Probe)
                            │       ├── table: default.tpch_10.supplier
                            │       ├── output columns: [s_suppkey (#33), s_nationkey (#36)]
                            │       ├── read rows: 100000
                            │       ├── read bytes: 227421
                            │       ├── partitions total: 1
                            │       ├── partitions scanned: 1
                            │       ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 1 to 1, bloom pruning: 0 to 0>]
                            │       ├── push downs: [filters: [], limit: NONE]
                            │       └── estimated rows: 100000.00
                            └── TableScan(Probe)
                                ├── table: default.tpch_10.partsupp
                                ├── output columns: [ps_partkey (#28), ps_suppkey (#29), ps_supplycost (#31)]
                                ├── read rows: 8000000
                                ├── read bytes: 37277453
                                ├── partitions total: 12
                                ├── partitions scanned: 12
                                ├── pruning stats: [segments: <range pruning: 1 to 1>, blocks: <range pruning: 12 to 12, bloom pruning: 0 to 0>]
                                ├── push downs: [filters: [], limit: NONE]
                                └── estimated rows: 8000000.00

185 rows explain in 0.519 sec. Processed 0 rows, 0B (0 rows/s, 0B/s)

```
