### PR TITLE
fix(bindings/python): remove repository field for maturin

### DIFF
--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -112,7 +112,7 @@ jobs:
       id-token: write
     environment:
       name: npmjs
-      url: https://www.npmjs.com/package/databend-driver/v/${{ github.ref_name }}
+      url: https://www.npmjs.com/package/databend-driver
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -112,7 +112,7 @@ jobs:
       id-token: write
     environment:
       name: npmjs
-      url: https://www.npmjs.com/package/databend-driver/v/${{ github.ref }}
+      url: https://www.npmjs.com/package/databend-driver/v/${{ github.ref_name }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup node

--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -110,6 +110,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    environment:
+      name: npmjs
+      url: https://www.npmjs.com/package/databend-driver/v/${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
       - name: Setup node
@@ -143,5 +146,5 @@ jobs:
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
           npm publish --access public --provenance
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -92,7 +92,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/p/databend-driver/${{ github.ref_name }}/
+      url: https://pypi.org/p/databend-driver/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -92,7 +92,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/p/databend-driver/${{ github.ref }}/
+      url: https://pypi.org/p/databend-driver/${{ github.ref_name }}/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -92,7 +92,7 @@ jobs:
       id-token: write
     environment:
       name: pypi
-      url: https://pypi.org/p/databend-driver
+      url: https://pypi.org/p/databend-driver/${{ github.ref }}/
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   crates:
     runs-on: ubuntu-latest
+    environment:
+      name: crates
+      url: https://crates.io/crates/bendsql/${{ github.ref }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Cargo Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: crates
-      url: https://crates.io/crates/bendsql/${{ github.ref }}
+      url: https://crates.io/crates/bendsql/${{ github.ref_name }}
     steps:
     - uses: actions/checkout@v4
     - name: Setup Cargo Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: crates
-      url: https://crates.io/crates/bendsql/${{ github.ref_name }}
+      url: https://crates.io/crates/databend-driver
     steps:
     - uses: actions/checkout@v4
     - name: Setup Cargo Release

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -6,7 +6,6 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 authors = { workspace = true }
-repository = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Maturin use it to add a Source Code project url if provided.
Avoid error `Invalid value for project_urls. Error: Use both a label and an URL.` in pypi publish.