### PR TITLE
feat(core): handle role and secondary_roles in SessionConfig

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -334,10 +334,7 @@ impl APIClient {
         if database.is_none() && session_settings.is_empty() {
             return None;
         }
-        let mut session = SessionConfig {
-            database: None,
-            settings: None,
-        };
+        let mut session = SessionConfig::default();
         if database.is_some() {
             session.database = database.clone();
         }

--- a/core/src/request.rs
+++ b/core/src/request.rs
@@ -16,12 +16,16 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 pub struct SessionConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settings: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secondary_roles: Option<Vec<String>>,
 }
 
 #[derive(Serialize, Debug)]
@@ -94,6 +98,8 @@ mod test {
             .with_session(Some(SessionConfig {
                 database: Some("default".to_string()),
                 settings: Some(BTreeMap::new()),
+                role: None,
+                secondary_roles: None,
             }))
             .with_pagination(Some(PaginationConfig {
                 wait_time_secs: Some(1),

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -68,3 +68,27 @@ pub struct QueryResponse {
     pub next_uri: Option<String>,
     pub kill_uri: Option<String>,
 }
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn deserailize_session_config() {
+        let session_json = r#"{"database":"default","settings":{}}"#;
+        let session_config: SessionConfig = serde_json::from_str(session_json).unwrap();
+        assert_eq!(session_config.database, Some("default".to_string()));
+        assert_eq!(session_config.settings, Some(BTreeMap::default()));
+        assert_eq!(session_config.role, None);
+        assert_eq!(session_config.secondary_roles, None);
+
+        let session_json = r#"{"database":"default","settings":{},"role": "role1", "secondary_roles": [], "unknown_field": 1}"#;
+        let session_config: SessionConfig = serde_json::from_str(session_json).unwrap();
+        assert_eq!(session_config.database, Some("default".to_string()));
+        assert_eq!(session_config.settings, Some(BTreeMap::default()));
+        assert_eq!(session_config.role, Some("role1".to_string()));
+        assert_eq!(session_config.secondary_roles, Some(vec![]));
+    }
+}

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -76,7 +76,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn deserailize_session_config() {
+    fn deserialize_session_config() {
         let session_json = r#"{"database":"default","settings":{}}"#;
         let session_config: SessionConfig = serde_json::from_str(session_json).unwrap();
         assert_eq!(session_config.database, Some("default".to_string()));


### PR DESCRIPTION
SessionConfig is used to store the session state across multiple queries in one client session.

After user setting `SET ROLE role1`, session config will contain `role: role1` in the response, then the client can pass `role: role1` to the next query's header, thus allows user to change role in a client view.

The `secondary_roles` is still under development in databend (https://github.com/datafuselabs/databend/pull/13673) but IMHO adding a `secondary_roles` field will not break the deserialization even the server did not respond this field at all.