### PR TITLE
fix: handle SET ROLE properly

### DIFF
--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -33,7 +33,7 @@ use crate::presign::{presign_upload_to_stage, PresignedResponse, Reader};
 use crate::stage::StageLocation;
 use crate::{
     error::{Error, Result},
-    request::{PaginationConfig, QueryRequest, SessionConfig, StageAttachmentConfig},
+    request::{PaginationConfig, QueryRequest, SessionState, StageAttachmentConfig},
     response::{QueryError, QueryResponse},
 };
 
@@ -59,7 +59,7 @@ pub struct APIClient {
     tenant: Option<String>,
     warehouse: Arc<Mutex<Option<String>>>,
     database: Arc<Mutex<Option<String>>>,
-    session_settings: Arc<Mutex<BTreeMap<String, String>>>,
+    session_state: Arc<Mutex<SessionState>>,
 
     wait_time_secs: Option<i64>,
     max_rows_in_buffer: Option<i64>,
@@ -87,7 +87,7 @@ impl APIClient {
             "" => None,
             s => Some(s.to_string()),
         };
-        client.database = Arc::new(Mutex::new(database));
+        client.database = Arc::new(Mutex::new(database.clone()));
         let mut scheme = "https";
         let mut session_settings = BTreeMap::new();
         for (k, v) in u.query_pairs() {
@@ -164,8 +164,12 @@ impl APIClient {
         }
         client.cli = cli_builder.build()?;
         client.endpoint = Url::parse(&format!("{}://{}:{}", scheme, client.host, client.port))?;
-        client.session_settings = Arc::new(Mutex::new(session_settings));
 
+        client.session_state = Arc::new(Mutex::new(
+            SessionState::default()
+                .with_settings(Some(session_settings))
+                .with_database(database),
+        ));
         Ok(client)
     }
 
@@ -183,35 +187,39 @@ impl APIClient {
         uuid::Uuid::new_v4().to_string()
     }
 
-    pub async fn handle_session(&self, session: &Option<SessionConfig>) {
-        let mut session_settings = self.session_settings.lock().await;
-        if let Some(session) = &session {
-            if session.database.is_some() {
-                let mut database = self.database.lock().await;
-                *database = session.database.clone();
-            }
-            if let Some(settings) = &session.settings {
-                for (k, v) in settings {
-                    match k.as_str() {
-                        "warehouse" => {
-                            let mut warehouse = self.warehouse.lock().await;
-                            *warehouse = Some(v.clone());
-                        }
-                        _ => {
-                            session_settings.insert(k.clone(), v.clone());
-                        }
-                    }
-                }
+    pub async fn handle_session(&self, session: &Option<SessionState>) {
+        let session = match session {
+            Some(session) => session,
+            None => return,
+        };
+
+        // save the updated session state from the server side
+        {
+            let mut session_state = self.session_state.lock().await;
+            *session_state = session.clone();
+        }
+
+        // process database changed via session.db
+        if session.database.is_some() {
+            let mut database = self.database.lock().await;
+            *database = session.database.clone();
+        }
+
+        // process warehouse changed via session settings
+        if let Some(settings) = session.settings.as_ref() {
+            if let Some(v) = settings.get("warehouse") {
+                let mut warehouse = self.warehouse.lock().await;
+                *warehouse = Some(v.clone());
             }
         }
     }
 
     pub async fn start_query(&self, sql: &str) -> Result<QueryResponse> {
         info!("start query: {}", sql);
-        let session_settings = self.make_session().await;
+        let session_state = self.session_state().await;
         let req = QueryRequest::new(sql)
             .with_pagination(self.make_pagination())
-            .with_session(session_settings);
+            .with_session(Some(session_state));
         let endpoint = self.endpoint.join("v1/query")?;
         let query_id = self.gen_query_id();
         let headers = self.make_headers(&query_id).await?;
@@ -334,20 +342,8 @@ impl APIClient {
         self.wait_for_query(resp).await
     }
 
-    async fn make_session(&self) -> Option<SessionConfig> {
-        let session_settings = self.session_settings.lock().await;
-        let database = self.database.lock().await;
-        if database.is_none() && session_settings.is_empty() {
-            return None;
-        }
-        let mut session = SessionConfig::default();
-        if database.is_some() {
-            session.database = database.clone();
-        }
-        if !session_settings.is_empty() {
-            session.settings = Some(session_settings.clone());
-        }
-        Some(session)
+    async fn session_state(&self) -> SessionState {
+        self.session_state.lock().await.clone()
     }
 
     fn make_pagination(&self) -> Option<PaginationConfig> {
@@ -398,7 +394,7 @@ impl APIClient {
             "insert with stage: {}, format: {:?}, copy: {:?}",
             sql, file_format_options, copy_options
         );
-        let session_settings = self.make_session().await;
+        let session_state = self.session_state().await;
         let stage_attachment = Some(StageAttachmentConfig {
             location: stage,
             file_format_options: Some(file_format_options),
@@ -406,7 +402,7 @@ impl APIClient {
         });
         let req = QueryRequest::new(sql)
             .with_pagination(self.make_pagination())
-            .with_session(session_settings)
+            .with_session(Some(session_state))
             .with_stage_attachment(stage_attachment);
         let endpoint = self.endpoint.join("v1/query")?;
         let query_id = self.gen_query_id();
@@ -539,7 +535,7 @@ impl Default for APIClient {
             database: Arc::new(Mutex::new(None)),
             user: "root".to_string(),
             password: None,
-            session_settings: Arc::new(Mutex::new(BTreeMap::new())),
+            session_state: Arc::new(Mutex::new(SessionState::default())),
             wait_time_secs: None,
             max_rows_in_buffer: None,
             max_rows_per_page: None,

--- a/core/src/request.rs
+++ b/core/src/request.rs
@@ -16,8 +16,8 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Default)]
-pub struct SessionConfig {
+#[derive(Deserialize, Serialize, Debug, Default, Clone)]
+pub struct SessionState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub database: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -28,10 +28,27 @@ pub struct SessionConfig {
     pub secondary_roles: Option<Vec<String>>,
 }
 
+impl SessionState {
+    pub fn with_settings(mut self, settings: Option<BTreeMap<String, String>>) -> Self {
+        self.settings = settings;
+        self
+    }
+
+    pub fn with_database(mut self, database: Option<String>) -> Self {
+        self.database = database;
+        self
+    }
+
+    pub fn with_role(mut self, role: Option<String>) -> Self {
+        self.role = role;
+        self
+    }
+}
+
 #[derive(Serialize, Debug)]
 pub struct QueryRequest<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    session: Option<SessionConfig>,
+    session: Option<SessionState>,
     sql: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pagination: Option<PaginationConfig>,
@@ -68,7 +85,7 @@ impl<'r, 't: 'r> QueryRequest<'r> {
         }
     }
 
-    pub fn with_session(mut self, session: Option<SessionConfig>) -> Self {
+    pub fn with_session(mut self, session: Option<SessionState>) -> Self {
         self.session = session;
         self
     }
@@ -95,7 +112,7 @@ mod test {
     #[test]
     fn build_request() -> Result<()> {
         let req = QueryRequest::new("select 1")
-            .with_session(Some(SessionConfig {
+            .with_session(Some(SessionState {
                 database: Some("default".to_string()),
                 settings: Some(BTreeMap::new()),
                 role: None,

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -14,7 +14,7 @@
 
 use serde::Deserialize;
 
-use crate::request::SessionConfig;
+use crate::request::SessionState;
 
 #[derive(Deserialize, Debug)]
 pub struct QueryError {
@@ -56,7 +56,7 @@ pub struct SchemaField {
 pub struct QueryResponse {
     pub id: String,
     pub session_id: Option<String>,
-    pub session: Option<SessionConfig>,
+    pub session: Option<SessionState>,
     pub schema: Vec<SchemaField>,
     pub data: Vec<Vec<String>>,
     pub state: String,
@@ -78,14 +78,14 @@ mod test {
     #[test]
     fn deserialize_session_config() {
         let session_json = r#"{"database":"default","settings":{}}"#;
-        let session_config: SessionConfig = serde_json::from_str(session_json).unwrap();
+        let session_config: SessionState = serde_json::from_str(session_json).unwrap();
         assert_eq!(session_config.database, Some("default".to_string()));
         assert_eq!(session_config.settings, Some(BTreeMap::default()));
         assert_eq!(session_config.role, None);
         assert_eq!(session_config.secondary_roles, None);
 
         let session_json = r#"{"database":"default","settings":{},"role": "role1", "secondary_roles": [], "unknown_field": 1}"#;
-        let session_config: SessionConfig = serde_json::from_str(session_json).unwrap();
+        let session_config: SessionState = serde_json::from_str(session_json).unwrap();
         assert_eq!(session_config.database, Some("default".to_string()));
         assert_eq!(session_config.settings, Some(BTreeMap::default()));
         assert_eq!(session_config.role, Some("role1".to_string()));


### PR DESCRIPTION
this PR handles the SessionState as a whole:

1. on starting each query, it send the SessionState to the query instance
2. query instance responses a new SessionState to the client, and the client just save it
3. client pick the reponded SessionState to the next query

this may help reduce the cognize load when adding things into the SessionState, do not need `handle_session()` and `make_session()` with understanding of the fields, all we need is to pass it as a whole.