### PR TITLE
chore: handle warnings from backend

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -227,6 +227,7 @@ impl ConnectionArgs {
             _ = dsn.set_scheme("databend+https");
         }
         let mut query = url::form_urlencoded::Serializer::new(String::new());
+        query.append_pair("display_warnings", "1");
         if !self.args.is_empty() {
             for (k, v) in self.args {
                 query.append_pair(&k, &v);

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -70,6 +70,7 @@ pub struct APIClient {
     tls_ca_file: Option<String>,
 
     presigned_url_disabled: bool,
+    display_warnings: bool,
 }
 
 impl APIClient {
@@ -148,6 +149,18 @@ impl APIClient {
                 }
                 "access_token_file" => {
                     client.auth = Arc::new(AccessTokenFileAuth::new(v.to_string()));
+                }
+                "display_warnings" => {
+                    client.display_warnings = match v.as_ref() {
+                        "true" | "1" => true,
+                        "false" | "0" => false,
+                        _ => {
+                            return Err(Error::BadArgument(format!(
+                                "Invalid value for display_warnings: {}",
+                                v
+                            )))
+                        }
+                    }
                 }
                 _ => {
                     session_settings.insert(k.to_string(), v.to_string());
@@ -231,6 +244,9 @@ impl APIClient {
     }
 
     pub fn handle_warnings(&self, warnings: &[String]) {
+        if !self.display_warnings {
+            return;
+        }
         for w in warnings {
             warn!("warning from server: {}", w);
         }
@@ -535,6 +551,7 @@ impl Default for APIClient {
             page_request_timeout: Duration::from_secs(30),
             tls_ca_file: None,
             presigned_url_disabled: false,
+            display_warnings: false,
         }
     }
 }

--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -61,6 +61,7 @@ pub struct QueryResponse {
     pub data: Vec<Vec<String>>,
     pub state: String,
     pub error: Option<QueryError>,
+    pub warnings: Vec<String>,
     pub stats: QueryStats,
     // pub affect: Option<QueryAffect>,
     pub stats_uri: Option<String>,


### PR DESCRIPTION
we added an extra `warnings` field in the response from query.

on some corner cases when some tables are failed to be listed in the `SHOW TABLES` statement, we'd perfer return `warnings` instead of errors, which would break all the output.

