### PR TITLE
fix(driver): don't call wake_by_ref in Poll::Pending

### DIFF
--- a/driver/src/flight_sql.rs
+++ b/driver/src/flight_sql.rs
@@ -377,10 +377,7 @@ impl Stream for FlightSQLRows {
             }
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err.into()))),
             Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => {
-                cx.waker().wake_by_ref();
-                Poll::Pending
-            }
+            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/driver/src/rest_api.rs
+++ b/driver/src/rest_api.rs
@@ -276,10 +276,7 @@ impl Stream for RestAPIRows {
                     self.next_page = None;
                     Poll::Ready(Some(Err(e)))
                 }
-                Poll::Pending => {
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                }
+                Poll::Pending => Poll::Pending,
             },
             None => match self.next_uri {
                 Some(ref next_uri) => {


### PR DESCRIPTION

Now execute sql:

```
echo "SELECT number, NTH_VALUE(number, 2) OVER (ORDER BY score DESC) FROM (select number::string number , number % 100 as score from numbers(300000000) ) ignore_result;" | bendsql
```

The CPU load just takes 0.1% instead of 100%.