### PR TITLE
chore: bump version to 0.13.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.3"
+version = "0.13.4"
 edition = "2021"
 license = "Apache-2.0"
 authors = ["Databend Authors <opensource@datafuselabs.com>"]
@@ -21,7 +21,7 @@ keywords = ["databend", "database"]
 repository = "https://github.com/datafuselabs/bendsql"
 
 [workspace.dependencies]
-databend-client = { path = "core", version = "0.13.3" }
-databend-driver = { path = "driver", version = "0.13.3" }
-databend-driver-macros = { path = "macros", version = "0.13.3" }
-databend-sql = { path = "sql", version = "0.13.3" }
+databend-client = { path = "core", version = "0.13.4" }
+databend-driver = { path = "driver", version = "0.13.4" }
+databend-driver-macros = { path = "macros", version = "0.13.4" }
+databend-sql = { path = "sql", version = "0.13.4" }

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-arm64",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-x64",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-arm64-gnu",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-x64-gnu",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-win32-x64-msvc",
   "repository": "https://github.com/datafuselabs/bendsql.git",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "os": [
     "win32"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "databend-driver",
   "author": "Databend Authors <opensource@datafuselabs.com>",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
I just tested the support for UDFScript. I think we should try to release 0.13.4 to enable it.