### PR TITLE
fix: the first resp may not contain schema.

### DIFF
--- a/core/src/response.rs
+++ b/core/src/response.rs
@@ -45,7 +45,7 @@ pub struct ProgressValues {
     pub bytes: usize,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct SchemaField {
     pub name: String,
     #[serde(rename = "type")]


### PR DESCRIPTION


1. client used to wait for schema in the server side.  So the user experience has not worsened.
2. when API `query_iter` is used. user is expected to used the result, so need to wait however.
3. other ways to handle the late schema need refactor of both user and inner interfaces,   let`consider it later.
