### PR TITLE
chore(docs): add type mappings

### DIFF
--- a/bindings/nodejs/README.md
+++ b/bindings/nodejs/README.md
@@ -36,6 +36,38 @@ while (row) {
 }
 ```
 
+## Type Mapping
+
+[Databend Types](https://docs.databend.com/sql/sql-reference/data-types/)
+
+### General Data Types
+
+| Databend    | Node.js         |
+| ----------- | --------------- |
+| `BOOLEAN`   | `Boolean`       |
+| `TINYINT`   | `Number`        |
+| `SMALLINT`  | `Number`        |
+| `INT`       | `Number`        |
+| `BIGINT`    | `Number`        |
+| `FLOAT`     | `Number`        |
+| `DOUBLE`    | `Number`        |
+| `DECIMAL`   | `String`        |
+| `DATE`      | `Date`          |
+| `TIMESTAMP` | `Date`          |
+| `VARCHAR`   | `String`        |
+| `BINARY`    | `Array(Number)` |
+
+### Semi-Structured Data Types
+
+| Databend   | Node.js  |
+| ---------- | -------- |
+| `ARRAY`    | `Array`  |
+| `TUPLE`    | `Array`  |
+| `MAP`      | `Object` |
+| `VARIANT`  | `String` |
+| `BITMAP`   | `String` |
+| `GEOMETRY` | `String` |
+
 ## Development
 
 ```shell

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -9,7 +9,6 @@ maturin develop
 
 ## Usage
 
-
 ### Blocking
 
 ```python
@@ -64,6 +63,38 @@ async def main():
 asyncio.run(main())
 ```
 
+## Type Mapping
+
+[Databend Types](https://docs.databend.com/sql/sql-reference/data-types/)
+
+### General Data Types
+
+| Databend    | Python              |
+| ----------- | ------------------- |
+| `BOOLEAN`   | `bool`              |
+| `TINYINT`   | `int`               |
+| `SMALLINT`  | `int`               |
+| `INT`       | `int`               |
+| `BIGINT`    | `int`               |
+| `FLOAT`     | `float`             |
+| `DOUBLE`    | `float`             |
+| `DECIMAL`   | `decimal.Decimal`   |
+| `DATE`      | `datetime.date`     |
+| `TIMESTAMP` | `datetime.datetime` |
+| `VARCHAR`   | `str`               |
+| `BINARY`    | `bytes`             |
+
+### Semi-Structured Data Types
+
+| Databend   | Python  |
+| ---------- | ------- |
+| `ARRAY`    | `list`  |
+| `TUPLE`    | `tuple` |
+| `MAP`      | `dict`  |
+| `VARIANT`  | `str`   |
+| `BITMAP`   | `str`   |
+| `GEOMETRY` | `str`   |
+
 ## APIs
 
 ### AsyncDatabendClient
@@ -105,7 +136,6 @@ class BlockingDatabendConnection:
     def query_iter(self, sql: str) -> RowIterator: ...
     def stream_load(self, sql: str, data: list[list[str]]) -> ServerStats: ...
 ```
-
 
 ### Row
 

--- a/driver/README.md
+++ b/driver/README.md
@@ -43,3 +43,35 @@ while let Some(row) = rows.next().await {
     println!("{} {} {}", title, author, date);
 }
 ```
+
+## Type Mapping
+
+[Databend Types](https://docs.databend.com/sql/sql-reference/data-types/)
+
+### General Data Types
+
+| Databend    | Rust                    |
+| ----------- | ----------------------- |
+| `BOOLEAN`   | `bool`                  |
+| `TINYINT`   | `i8`,`u8`               |
+| `SMALLINT`  | `i16`,`u16`             |
+| `INT`       | `i32`,`u32`             |
+| `BIGINT`    | `i64`,`u64`             |
+| `FLOAT`     | `f32`                   |
+| `DOUBLE`    | `f64`                   |
+| `DECIMAL`   | `String`                |
+| `DATE`      | `chrono::NaiveDate`     |
+| `TIMESTAMP` | `chrono::NaiveDateTime` |
+| `VARCHAR`   | `String`                |
+| `BINARY`    | `Vec<u8>`               |
+
+### Semi-Structured Data Types
+
+| Databend      | Rust            |
+| ------------- | --------------- |
+| `ARRAY[T]`    | `Vec<T>`        |
+| `TUPLE[T, U]` | `(T, U)`        |
+| `MAP[K, V]`   | `HashMap<K, V>` |
+| `VARIANT`     | `String`        |
+| `BITMAP`      | `String`        |
+| `GEOMETRY`    | `String`        |


### PR DESCRIPTION
Add type mapping for `Rust` driver and `Python`, `Node.js` binding.