### PR TITLE
feat(cli): new argument no-auto-complete

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -35,6 +35,7 @@ pub struct SettingsConfig {
     pub display_pretty_sql: Option<bool>,
     pub prompt: Option<String>,
     pub progress_color: Option<String>,
+    pub no_auto_complete: Option<bool>,
     pub show_progress: Option<bool>,
     pub show_stats: Option<bool>,
     pub expand: Option<String>,
@@ -67,6 +68,7 @@ pub struct Settings {
     pub display_pretty_sql: bool,
     pub prompt: String,
     pub progress_color: String,
+    pub no_auto_complete: bool,
 
     /// Show progress [bar] when executing queries.
     /// Only works with output format `table` and `null`.
@@ -139,6 +141,7 @@ impl Settings {
         self.progress_color = cfg
             .progress_color
             .unwrap_or_else(|| self.progress_color.clone());
+        self.no_auto_complete = cfg.no_auto_complete.unwrap_or(self.no_auto_complete);
         self.show_progress = cfg.show_progress.unwrap_or(self.show_progress);
         self.show_stats = cfg.show_stats.unwrap_or(self.show_stats);
         self.expand = cfg
@@ -235,6 +238,7 @@ impl Default for Settings {
             display_pretty_sql: true,
             progress_color: "cyan".to_string(),
             prompt: "{user}@{warehouse}/{database}> ".to_string(),
+            no_auto_complete: false,
             output_format: OutputFormat::Table,
             quote_style: OutputQuoteStyle::Necessary,
             expand: ExpandMode::Auto,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -161,6 +161,13 @@ struct Args {
     #[clap(short = 'n', long, help = "Force non-interactive mode")]
     non_interactive: bool,
 
+    #[clap(
+        short = 'A',
+        long,
+        help = "Disable loading tables and fields for auto-completion, which offers a quicker start"
+    )]
+    no_auto_complete: bool,
+
     #[clap(long, help = "Check for server status and exit")]
     check: bool,
 
@@ -318,6 +325,9 @@ pub async fn main() -> Result<()> {
 
     settings.merge_config(config.settings);
 
+    if args.no_auto_complete {
+        settings.no_auto_complete = true;
+    }
     if let Some(output) = args.output {
         settings.output_format = output;
     }

--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -88,16 +88,18 @@ impl Session {
             println!("Connected to {}", version);
             println!();
 
-            let rows = conn.query_iter(PROMPT_SQL).await;
-            match rows {
-                Ok(mut rows) => {
-                    while let Some(row) = rows.next().await {
-                        let name: (String,) = row.unwrap().try_into().unwrap();
-                        keywords.push(name.0);
+            if !settings.no_auto_complete {
+                let rows = conn.query_iter(PROMPT_SQL).await;
+                match rows {
+                    Ok(mut rows) => {
+                        while let Some(row) = rows.next().await {
+                            let name: (String,) = row.unwrap().try_into().unwrap();
+                            keywords.push(name.0);
+                        }
                     }
-                }
-                Err(e) => {
-                    eprintln!("loading auto complete keywords failed: {}", e);
+                    Err(e) => {
+                        eprintln!("loading auto complete keywords failed: {}", e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
With config field `no_auto_complete`.
To disable loading tables and fields for auto completion, offers a quicker start.

- fixes: #429