### PR TITLE
fix: allow select version() failed

### DIFF
--- a/cli/src/session.rs
+++ b/cli/src/session.rs
@@ -85,7 +85,7 @@ impl Session {
                     );
                 }
             }
-            let version = conn.version().await?;
+            let version = conn.version().await.unwrap_or_default();
             println!("Connected to {}", version);
             println!();
 
@@ -163,7 +163,7 @@ impl Session {
 
         // server version
         {
-            let version = self.conn.version().await?;
+            let version = self.conn.version().await.unwrap_or_default();
             println!("Server version: {}", version);
         }
 
@@ -540,7 +540,7 @@ impl Session {
                 "reconnecting to {}:{} as user {}.",
                 info.host, info.port, info.user
             );
-            let version = self.conn.version().await?;
+            let version = self.conn.version().await.unwrap_or_default();
             eprintln!("connected to {}", version);
             eprintln!();
         }

--- a/driver/src/conn.rs
+++ b/driver/src/conn.rs
@@ -93,13 +93,17 @@ pub trait Connection: DynClone + Send + Sync {
     async fn info(&self) -> ConnectionInfo;
 
     async fn version(&self) -> Result<String> {
-        let row = self.query_row("SELECT version()").await?;
+        let row = self.query_row("SELECT version()").await;
         let version = match row {
-            Some(row) => {
+            Ok(Some(row)) => {
                 let (version,): (String,) = row.try_into().map_err(Error::Parsing)?;
                 version
             }
-            None => "".to_string(),
+            Ok(None) => "".to_string(),
+            Err(e) => {
+                eprintln!("select version() failed: {}", e);
+                "".to_string()
+            }
         };
         Ok(version)
     }

--- a/driver/src/conn.rs
+++ b/driver/src/conn.rs
@@ -93,17 +93,13 @@ pub trait Connection: DynClone + Send + Sync {
     async fn info(&self) -> ConnectionInfo;
 
     async fn version(&self) -> Result<String> {
-        let row = self.query_row("SELECT version()").await;
+        let row = self.query_row("SELECT version()").await?;
         let version = match row {
-            Ok(Some(row)) => {
+            Some(row) => {
                 let (version,): (String,) = row.try_into().map_err(Error::Parsing)?;
                 version
             }
-            Ok(None) => "".to_string(),
-            Err(e) => {
-                eprintln!("select version() failed: {}", e);
-                "".to_string()
-            }
+            None => "".to_string(),
         };
         Ok(version)
     }


### PR DESCRIPTION
In PR https://github.com/datafuselabs/databend/pull/16031

We support the feature that user can continue login and change the password after the password expires. In this case, the user cannot perform other operations except changing the password. As a result, the SQL `select version()`, which is automatically sent by `BendSQL` fails to be executed and exits, causing the user can't change the password. This PR allows `select version()` to fail and not exit, and user can continue change password.
