### PR TITLE
chore: exit client after changing current user's password

### DIFF
--- a/cli/src/display.rs
+++ b/cli/src/display.rs
@@ -272,7 +272,7 @@ impl<'a> FormatDisplay<'a> {
             let (rows, mut rows_str, kind, total_rows, total_bytes) = match self.kind {
                 QueryKind::Explain => (self.rows, "rows", "explain", 0, 0),
                 QueryKind::Query => (self.rows, "rows", "read", stats.read_rows, stats.read_bytes),
-                QueryKind::Update => (
+                QueryKind::Update | QueryKind::AlterUserPassword => (
                     stats.write_rows,
                     "rows",
                     "written",


### PR DESCRIPTION
Exit client after changing the current user's password, user can login again with the new password.
This is because `BendSQL` continue use old password for following queries, which will result in login failure with message `Query Page failed with status 401 Unauthorized: {"error":{"code":"401","message":"wrong password"}}`

