### PR TITLE
feat: support new DataType TimestampTz

### DIFF
--- a/bindings/nodejs/src/lib.rs
+++ b/bindings/nodejs/src/lib.rs
@@ -339,6 +339,7 @@ impl ToNapiValue for Value<'_> {
                     String::to_napi_value(env, s.to_string())
                 }
             }
+            databend_driver::Value::TimestampTz(s) => String::to_napi_value(env, s.to_string()),
             databend_driver::Value::Geometry(s) => String::to_napi_value(env, s.to_string()),
             databend_driver::Value::Interval(s) => String::to_napi_value(env, s.to_string()),
             databend_driver::Value::Geography(s) => String::to_napi_value(env, s.to_string()),

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -99,6 +99,7 @@ impl<'py> IntoPyObject<'py> for Value {
                 let tuple = PyTuple::new(py, inner.into_iter().map(Value))?;
                 tuple.into_bound_py_any(py)?
             }
+            databend_driver::Value::TimestampTz(s) => s.into_bound_py_any(py)?,
             databend_driver::Value::Bitmap(s) => s.into_bound_py_any(py)?,
             databend_driver::Value::Variant(s) => s.into_bound_py_any(py)?,
             databend_driver::Value::Geometry(s) => s.into_bound_py_any(py)?,

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ clap = { version = "4.5", features = ["derive", "env"] }
 comfy-table = "7.1"
 csv = "1.3"
 ctrlc = { version = "3.4.6", features = ["termination"] }
-databend-common-ast = "0.2.1"
+databend-common-ast = "0.2.3"
 fern = { version = "0.7", features = ["colored"] }
 indicatif = "0.17"
 log = "0.4"

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -38,7 +38,7 @@ tonic = { workspace = true, optional = true }
 
 async-trait = "0.1"
 csv = "1.3"
-databend-common-ast = "0.2.2"
+databend-common-ast = "0.2.3"
 derive-visitor = { version = "0.4.0", features = ["std-types-drive"] }
 glob = "0.3"
 log = "0.4"

--- a/sql/src/schema.rs
+++ b/sql/src/schema.rs
@@ -87,6 +87,7 @@ pub enum DataType {
     Number(NumberDataType),
     Decimal(DecimalDataType),
     Timestamp,
+    TimestampTz,
     Date,
     Nullable(Box<DataType>),
     Array(Box<DataType>),
@@ -137,6 +138,7 @@ impl std::fmt::Display for DataType {
                 write!(f, "Decimal({}, {})", size.precision, size.scale)
             }
             DataType::Timestamp => write!(f, "Timestamp"),
+            DataType::TimestampTz => write!(f, "TimestampTz"),
             DataType::Date => write!(f, "Date"),
             DataType::Nullable(inner) => write!(f, "Nullable({inner})"),
             DataType::Array(inner) => write!(f, "Array({inner})"),
@@ -283,6 +285,7 @@ impl TryFrom<&TypeDesc<'_>> for DataType {
                 let dimension = desc.args[0].name.parse::<u64>()?;
                 DataType::Vector(dimension)
             }
+            "TimestampTz" => DataType::TimestampTz,
             _ => return Err(Error::Parsing(format!("Unknown type: {desc:?}"))),
         };
         Ok(dt)


### PR DESCRIPTION
ref: https://github.com/databendlabs/databend/pull/18892

```sql
root@localhost:8000/default/default> select to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000'));

select
  to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000'))

╭─────────────────────────────────────────────────────────────╮
│ to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000')) │
│                         TimestampTz                         │
├─────────────────────────────────────────────────────────────┤
│ 2021-12-20 17:01:01.000000 +0000                            │
╰─────────────────────────────────────────────────────────────╯
1 row read in 0.018 sec. Processed 1 row, 1 B (55.56 rows/s, 55 B/s)
```

