### PR TITLE
fix: DataType::TimestampTz display: "TimestampTz" -> "Timestamp_Tz"

### DIFF
--- a/sql/src/schema.rs
+++ b/sql/src/schema.rs
@@ -285,7 +285,7 @@ impl TryFrom<&TypeDesc<'_>> for DataType {
                 let dimension = desc.args[0].name.parse::<u64>()?;
                 DataType::Vector(dimension)
             }
-            "TimestampTz" => DataType::TimestampTz,
+            "Timestamp_Tz" => DataType::TimestampTz,
             _ => return Err(Error::Parsing(format!("Unknown type: {desc:?}"))),
         };
         Ok(dt)


### PR DESCRIPTION
before: https://github.com/databendlabs/bendsql/pull/696

```sql
select
  to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000'))

╭─────────────────────────────────────────────────────────────╮
│ to_timestamp_tz(to_timestamp('2021-12-20 17:01:01.000000')) │
│                         Timestamp_Tz                        │
├─────────────────────────────────────────────────────────────┤
│ 2021-12-20 17:01:01.000000 +0000                            │
╰─────────────────────────────────────────────────────────────╯
```

databend: https://github.com/databendlabs/databend/pull/18931