### PR TITLE
ci: skip Databend patch releases for nightly tests

### DIFF
--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -111,4 +111,12 @@ jobs:
         with:
           name: bindings-nodejs-x86_64-unknown-linux-gnu
           path: bindings/nodejs
-      - run: make -C tests test-bindings-nodejs
+      - name: Resolve Databend version
+        id: databend-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(gh api repos/databendlabs/databend/releases --jq '[.[] | select(.draft | not) | select(.tag_name | endswith("-nightly"))][0].tag_name')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Running integration tests with Databend version: **$version**" >> "$GITHUB_STEP_SUMMARY"
+      - run: make -C tests test-bindings-nodejs DATABEND_META_VERSION=${{ steps.databend-version.outputs.version }} DATABEND_QUERY_VERSION=${{ steps.databend-version.outputs.version }}

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -135,9 +135,17 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.pyver }}
+      - name: Resolve Databend version
+        id: databend-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(gh api repos/databendlabs/databend/releases --jq '[.[] | select(.draft | not) | select(.tag_name | endswith("-nightly"))][0].tag_name')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Running integration tests with Databend version: **$version**" >> "$GITHUB_STEP_SUMMARY"
       - name: Prepare
         working-directory: tests
-        run: make up
+        run: make up DATABEND_META_VERSION=${{ steps.databend-version.outputs.version }} DATABEND_QUERY_VERSION=${{ steps.databend-version.outputs.version }}
 #        env:
 #          DATABEND_META_VERSION: v1.2.898-nightly
 #          DATABEND_QUERY_VERSION: v1.2.898-nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,17 @@ jobs:
       #   run: |
       #     echo "::add-mask::${{ vars.DATABEND_LICENSE_TRIAL }}"
       #     echo "QUERY_DATABEND_ENTERPRISE_LICENSE=${{ vars.DATABEND_LICENSE_TRIAL }}" >> $GITHUB_ENV
-      - run: make -C tests test-core
-      - run: make -C tests test-driver
-      - run: make -C tests test-bendsql
+      - name: Resolve Databend version
+        id: databend-version
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          version=$(gh api repos/databendlabs/databend/releases --jq '[.[] | select(.draft | not) | select(.tag_name | endswith("-nightly"))][0].tag_name')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Running integration tests with Databend version: **$version**" >> "$GITHUB_STEP_SUMMARY"
+      - run: make -C tests test-core DATABEND_META_VERSION=${{ steps.databend-version.outputs.version }} DATABEND_QUERY_VERSION=${{ steps.databend-version.outputs.version }}
+      - run: make -C tests test-driver DATABEND_META_VERSION=${{ steps.databend-version.outputs.version }} DATABEND_QUERY_VERSION=${{ steps.databend-version.outputs.version }}
+      - run: make -C tests test-bendsql DATABEND_META_VERSION=${{ steps.databend-version.outputs.version }} DATABEND_QUERY_VERSION=${{ steps.databend-version.outputs.version }}
 
   bindings_python:
     needs: check

--- a/.github/workflows/cron.integration.yml
+++ b/.github/workflows/cron.integration.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          version=$(gh api repos/databendlabs/databend/releases --jq '.[0].tag_name')
+          version=$(gh api repos/databendlabs/databend/releases --jq '[.[] | select(.draft | not) | select(.tag_name | endswith("-nightly"))][0].tag_name')
           echo "version=$version" >> $GITHUB_OUTPUT
           echo "Running integration tests with Databend version: **$version**" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/cron.integration.yml
+++ b/.github/workflows/cron.integration.yml
@@ -39,11 +39,11 @@ jobs:
         with:
           cache-key: integration
       - name: Run Core Integration Tests
-        run: make -C tests test-core DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
+        run: make -C tests test-core DATABEND_META_VERSION=${{ needs.version.outputs.version }} DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
       - name: Run Driver Integration Tests
-        run: make -C tests test-driver DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
+        run: make -C tests test-driver DATABEND_META_VERSION=${{ needs.version.outputs.version }} DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
       - name: Run BendSQL Integration Tests
-        run: make -C tests test-bendsql DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
+        run: make -C tests test-bendsql DATABEND_META_VERSION=${{ needs.version.outputs.version }} DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
 
   build-python:
     name: build-python-${{ matrix.wheel }}
@@ -130,7 +130,7 @@ jobs:
           python-version: ${{ matrix.pyver }}
       - name: Prepare
         working-directory: tests
-        run: make up DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
+        run: make up DATABEND_META_VERSION=${{ needs.version.outputs.version }} DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
@@ -176,7 +176,7 @@ jobs:
         run: pnpm install
       - name: Prepare
         working-directory: tests
-        run: make up DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
+        run: make up DATABEND_META_VERSION=${{ needs.version.outputs.version }} DATABEND_QUERY_VERSION=${{ needs.version.outputs.version }}
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- choose the latest non-draft Databend release whose tag ends with `-nightly`
- skip patch releases such as `v1.2.888-patch-8` when selecting the integration test version
- pass the resolved version to both Databend meta and query images across integration workflows
- cover `ci.yml`, `cron.integration.yml`, `bindings.python.yml`, and `bindings.nodejs.yml`

## Tests
- `gh api repos/databendlabs/databend/releases --jq '[.[] | select(.draft | not) | select(.tag_name | endswith("-nightly"))][0].tag_name'`
- `git diff --check`
- `actionlint`