### PR TITLE
fix: PUT/GET stage path handling

### DIFF
--- a/cli/tests/03-put-get-paths.result
+++ b/cli/tests/03-put-get-paths.result
@@ -1,0 +1,16 @@
+---- put no match ----
+Error: BadArgument: No local files matched: <workdir>/src/missing*.csv
+---- put stage dir ----
+<workdir>/src/c.csv	SUCCESS	10
+---- get prefix ----
+<workdir>/dst/c.csv	SUCCESS	10
+---- get single file ----
+<workdir>/dst/c.csv	SUCCESS	10
+---- get local file ----
+Error: BadArgument: Local destination is not a directory: <workdir>/file-dst
+---- get no match ----
+Error: BadArgument: No stage files matched: @ss_03_put_get_paths/missing
+---- duplicate basename ----
+<workdir>/src/nested/a/same.csv	SUCCESS	7
+<workdir>/src/nested/b/same.csv	SUCCESS	7
+Error: BadArgument: Duplicate local file basename in GET results: same.csv

--- a/cli/tests/03-put-get-paths.sh
+++ b/cli/tests/03-put-get-paths.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -euo pipefail
+
+stage="ss_03_put_get_paths"
+workdir="/tmp/bendsql_put_get_paths"
+src="${workdir}/src"
+dst="${workdir}/dst"
+file_dst="${workdir}/file-dst"
+
+rm -rf "${workdir}"
+mkdir -p "${src}/nested/a" "${src}/nested/b"
+printf 'name\nroot\n' >"${src}/c.csv"
+printf 'name\na\n' >"${src}/nested/a/same.csv"
+printf 'name\nb\n' >"${src}/nested/b/same.csv"
+printf 'not a dir\n' >"${file_dst}"
+
+cleanup() {
+	echo "DROP STAGE IF EXISTS ${stage}" | ${BENDSQL} >/dev/null 2>&1 || true
+	rm -rf "${workdir}"
+}
+trap cleanup EXIT
+
+echo "DROP STAGE IF EXISTS ${stage}" | ${BENDSQL} >/dev/null
+echo "CREATE STAGE ${stage}" | ${BENDSQL} >/dev/null
+
+run_query() {
+	local query="$1"
+	set +e
+	echo "${query}" | BENDSQL_ERROR_NO_VERSION=1 RUST_BACKTRACE=0 ${BENDSQL} --output=tsv 2>&1 |
+		sed "s#${workdir}#<workdir>#g"
+	set -e
+}
+
+echo "---- put no match ----"
+run_query "put fs://${src}/missing*.csv @${stage}/prefix"
+
+echo "---- put stage dir ----"
+run_query "put fs://${src}/c.csv @${stage}/prefix"
+
+echo "---- get prefix ----"
+run_query "get @${stage}/prefix/c fs://${dst}"
+
+echo "---- get single file ----"
+rm -rf "${dst}"
+run_query "get @${stage}/prefix/c.csv fs://${dst}"
+
+echo "---- get local file ----"
+run_query "get @${stage}/prefix/c fs://${file_dst}"
+
+echo "---- get no match ----"
+run_query "get @${stage}/missing fs://${dst}"
+
+echo "---- duplicate basename ----"
+run_query "put fs://${src}/nested/a/same.csv @${stage}/dups/a"
+run_query "put fs://${src}/nested/b/same.csv @${stage}/dups/b"
+run_query "get @${stage}/dups fs://${dst}"

--- a/driver/src/conn.rs
+++ b/driver/src/conn.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
+use std::collections::BTreeSet;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -181,30 +183,45 @@ pub trait IConnection: Send + Sync {
         let mut total_size: usize = 0;
         let local_dsn = url::Url::parse(local_file)?;
         validate_local_scheme(local_dsn.scheme())?;
+        let entries = expand_local_glob(local_dsn.path())?;
         let mut results = Vec::new();
         let stage_location = StageLocation::try_from(stage)?;
         let schema = Arc::new(put_get_schema());
-        for entry in glob::glob(local_dsn.path())? {
-            let entry = entry?;
+        for entry in entries {
             let filename = entry
                 .file_name()
                 .ok_or_else(|| Error::BadArgument(format!("Invalid local file path: {entry:?}")))?
                 .to_str()
                 .ok_or_else(|| Error::BadArgument(format!("Invalid local file path: {entry:?}")))?;
             let stage_file = stage_location.file_path(filename);
-            let file = File::open(&entry).await?;
-            let size = file.metadata().await?.len();
-            let data = BufReader::new(file);
-            let (fname, status) = match self
-                .upload_to_stage(&stage_file, Box::new(data), size)
-                .await
-            {
-                Ok(_) => {
-                    total_count += 1;
-                    total_size += size as usize;
-                    (entry.to_string_lossy().to_string(), "SUCCESS".to_owned())
+            let (fname, status, size) = if entry.is_dir() {
+                (
+                    entry.to_string_lossy().to_string(),
+                    format!(
+                        "BadArgument: Local path is a directory: {}",
+                        entry.display()
+                    ),
+                    0,
+                )
+            } else {
+                let file = File::open(&entry).await?;
+                let size = file.metadata().await?.len();
+                let data = BufReader::new(file);
+                match self
+                    .upload_to_stage(&stage_file, Box::new(data), size)
+                    .await
+                {
+                    Ok(_) => {
+                        total_count += 1;
+                        total_size += size as usize;
+                        (
+                            entry.to_string_lossy().to_string(),
+                            "SUCCESS".to_owned(),
+                            size,
+                        )
+                    }
+                    Err(e) => (entry.to_string_lossy().to_string(), e.to_string(), size),
                 }
-                Err(e) => (entry.to_string_lossy().to_string(), e.to_string()),
             };
             let ss = ServerStats {
                 write_rows: total_count,
@@ -233,30 +250,37 @@ pub trait IConnection: Send + Sync {
         let mut total_size: usize = 0;
         let local_dsn = url::Url::parse(local_file)?;
         validate_local_scheme(local_dsn.scheme())?;
-        let mut location = StageLocation::try_from(stage)?;
-        if !location.path.ends_with('/') {
-            location.path.push('/');
-        }
+        ensure_local_destination_dir(local_dsn.path())?;
+        let location = StageLocation::try_from(stage)?;
         let list_sql = format!("LIST {location}");
         let mut response = self.query_iter(&list_sql).await?;
+        let mut files = Vec::new();
         let mut results = Vec::new();
         let schema = Arc::new(put_get_schema());
         while let Some(row) = response.next().await {
-            let (mut name, _, _, _, _): (String, u64, Option<String>, String, Option<String>) =
+            let (name, _, _, _, _): (String, u64, Option<String>, String, Option<String>) =
                 row?.try_into().map_err(Error::Parsing)?;
-            if !location.path.is_empty() && name.starts_with(&location.path) {
-                name = name[location.path.len()..].to_string();
+            if let Some(file) = normalize_stage_list_entry(&location, &name)? {
+                files.push(file);
             }
-            let stage_file = format!("{location}/{name}");
-            let presign = self.get_presigned_url("DOWNLOAD", &stage_file).await?;
-            let local_file = Path::new(local_dsn.path()).join(&name);
-            let status = presign_download_from_stage(presign, &local_file).await;
-            let (status, size) = match status {
-                Ok(size) => {
-                    total_count += 1;
-                    total_size += size as usize;
-                    ("SUCCESS".to_owned(), size)
-                }
+        }
+        if files.is_empty() {
+            return Err(Error::BadArgument(format!(
+                "No stage files matched: {stage}"
+            )));
+        }
+        ensure_unique_basenames(&files)?;
+        for file in files {
+            let local_file = Path::new(local_dsn.path()).join(&file.basename);
+            let (status, size) = match self.get_presigned_url("DOWNLOAD", &file.stage_file).await {
+                Ok(presign) => match presign_download_from_stage(presign, &local_file).await {
+                    Ok(size) => {
+                        total_count += 1;
+                        total_size += size as usize;
+                        ("SUCCESS".to_owned(), size)
+                    }
+                    Err(e) => (e.to_string(), 0),
+                },
                 Err(e) => (e.to_string(), 0),
             };
             let ss = ServerStats {
@@ -279,6 +303,78 @@ pub trait IConnection: Send + Sync {
             Box::pin(tokio_stream::iter(results)),
         ))
     }
+}
+
+#[derive(Debug, Clone)]
+struct StageFile {
+    stage_file: String,
+    basename: String,
+}
+
+fn expand_local_glob(pattern: &str) -> Result<Vec<PathBuf>> {
+    let entries = glob::glob(pattern)?.collect::<std::result::Result<Vec<_>, _>>()?;
+    if entries.is_empty() {
+        return Err(Error::BadArgument(format!(
+            "No local files matched: {pattern}"
+        )));
+    }
+    Ok(entries)
+}
+
+fn ensure_local_destination_dir(path: &str) -> Result<()> {
+    let local_path = Path::new(path);
+    if local_path.exists() && !local_path.is_dir() {
+        return Err(Error::BadArgument(format!(
+            "Local destination is not a directory: {path}"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_stage_list_entry(
+    location: &StageLocation,
+    listed_name: &str,
+) -> Result<Option<StageFile>> {
+    let stage_prefix = format!("{}/", location.name);
+    let relative = if let Some(path) = listed_name.strip_prefix(&stage_prefix) {
+        if !location.path.is_empty() && !path.starts_with(&location.path) {
+            return Ok(None);
+        }
+        path
+    } else if location.path.is_empty() || listed_name.starts_with(&location.path) {
+        listed_name
+    } else {
+        return Ok(None);
+    };
+
+    let basename = Path::new(relative)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| Error::BadArgument(format!("Invalid stage file path: {listed_name}")))?
+        .to_string();
+    let stage_file = if listed_name.starts_with(&stage_prefix) {
+        format!("@{listed_name}")
+    } else {
+        format!("@{}/{}", location.name, relative)
+    };
+
+    Ok(Some(StageFile {
+        stage_file,
+        basename,
+    }))
+}
+
+fn ensure_unique_basenames(files: &[StageFile]) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for file in files {
+        if !seen.insert(file.basename.clone()) {
+            return Err(Error::BadArgument(format!(
+                "Duplicate local file basename in GET results: {}",
+                file.basename
+            )));
+        }
+    }
+    Ok(())
 }
 
 fn put_get_schema() -> Schema {

--- a/sql/src/error.rs
+++ b/sql/src/error.rs
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::LazyLock;
+
+static ERROR_VERSION_SUFFIX: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("BENDSQL_ERROR_NO_VERSION").is_err());
+
 #[derive(Debug)]
 pub struct ConvertError {
     target: &'static str,
@@ -82,12 +87,12 @@ impl Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} [v{}]",
-            self.formatted_message(),
-            env!("CARGO_PKG_VERSION")
-        )
+        let msg = self.formatted_message();
+        if *ERROR_VERSION_SUFFIX {
+            write!(f, "{msg} [v{}]", env!("CARGO_PKG_VERSION"))
+        } else {
+            write!(f, "{msg}")
+        }
     }
 }
 


### PR DESCRIPTION
## Motivation

`PUT` and `GET` had several path handling gaps: local glob misses were silent, `GET` forced stage paths into directory form, returned `LIST` paths could be recombined incorrectly, presign errors could abort before CLI output, and downloads could overwrite files with duplicate basenames.

## Summary

- report clear errors for unmatched local `PUT` globs and unmatched `GET` stage prefixes
- treat stage paths as prefixes/directories without adding broken extra slashes
- normalize `LIST` output before presigning downloads
- reject file destinations and duplicate local basenames for `GET`
- add CLI coverage for REST and Flight SQL paths

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p databend-client stage`
- `cargo test -p databend-driver`
- `./cli/test.sh http 03-put-get-paths`
- `./cli/test.sh flight 03-put-get-paths`