### PR TITLE
feat: add Python 3.14 support for Python bindings

### DIFF
--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14"
+          python-version: "3.13"
 
       - uses: wntrblm/nox@2025.05.01
       - name: Download artifact

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         body: ["arrow", "json"]
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - uses: wntrblm/nox@2025.05.01
       - name: Download artifact

--- a/.github/workflows/cron.integration.yml
+++ b/.github/workflows/cron.integration.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Python

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 
     "License :: OSI Approved :: Apache Software License",
 
@@ -32,7 +33,7 @@ description = "Databend Driver Python Binding"
 license = { text = "Apache-2.0" }
 name = "databend-driver"
 readme = "README.md"
-requires-python = ">=3.8, < 3.14"
+requires-python = ">=3.8, < 3.15"
 dynamic = ["version"]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- allow Python 3.14 by changing the upper bound to <3.15
- add the Python 3.14 trove classifier
- include Python 3.14 in Python binding integration and cron integration matrices
- run the compat job on Python 3.14

## Test
- Python 3.14.5 metadata smoke test
- `uv pip compile bindings/python/pyproject.toml --extra local --python python3.14 --quiet`
- `python -m behave tests/local` in a Python 3.14.5 virtual environment
- installed current `databend-driver[local]` in a Python 3.14.5 virtual environment and verified `connect`, `connect_local`, memory queries, persistent local connection, and parquet registration