### PR TITLE
ci: retry docker compose image pulls

### DIFF
--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -91,6 +91,8 @@ jobs:
     name: integration-${{ matrix.ver }}
     needs: build
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_PARALLEL_LIMIT: "1"
     strategy:
       matrix:
         ver: ["18", "20", "22"]

--- a/.github/workflows/bindings.python.yml
+++ b/.github/workflows/bindings.python.yml
@@ -125,6 +125,8 @@ jobs:
     name: integration-${{ matrix.pyver }}-${{matrix.body}}
     needs: build
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_PARALLEL_LIMIT: "1"
     strategy:
       matrix:
         pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
   integration:
     needs: check
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_PARALLEL_LIMIT: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/.github/workflows/cron.integration.yml
+++ b/.github/workflows/cron.integration.yml
@@ -33,6 +33,8 @@ jobs:
   integration:
     needs: version
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_PARALLEL_LIMIT: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup
@@ -119,6 +121,8 @@ jobs:
   integration-python:
     needs: [version, build-python]
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_PARALLEL_LIMIT: "1"
     strategy:
       matrix:
         pyver: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -159,6 +163,8 @@ jobs:
   integration-nodejs:
     needs: [version, build-nodejs]
     runs-on: ubuntu-latest
+    env:
+      COMPOSE_PARALLEL_LIMIT: "1"
     strategy:
       matrix:
         ver: ["18", "20", "22"]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,7 @@
 DATABEND_META_VERSION ?= nightly
 DATABEND_QUERY_VERSION ?= nightly
 PYTHON ?= python3
+DOCKER_PULL_RETRIES ?= 3
 
 default: run
 
@@ -9,8 +10,25 @@ run: test-core test-driver test-bendsql down
 prepare:
 	mkdir -p data/databend
 
-up: prepare
-	docker compose up --scale query=3 --quiet-pull -d  --wait
+pull-images:
+	@attempt=1; \
+	while [ $$attempt -le $(DOCKER_PULL_RETRIES) ]; do \
+		echo "Pulling Docker images, attempt $$attempt/$(DOCKER_PULL_RETRIES)"; \
+		if docker compose pull --policy always --quiet; then \
+			exit 0; \
+		fi; \
+		if [ $$attempt -eq $(DOCKER_PULL_RETRIES) ]; then \
+			echo "Docker image pull failed after $(DOCKER_PULL_RETRIES) attempts"; \
+			exit 1; \
+		fi; \
+		sleep_seconds=$$((attempt * 10)); \
+		echo "Docker image pull failed; retrying in $${sleep_seconds}s"; \
+		sleep $$sleep_seconds; \
+		attempt=$$((attempt + 1)); \
+	done
+
+up: prepare pull-images
+	docker compose up --scale query=3 --pull never --force-recreate --quiet-pull -d  --wait
 	grep -q '127.0.0.1 minio' /etc/hosts || echo '127.0.0.1 minio' | sudo tee -a /etc/hosts > /dev/null
 	curl  -u root: -XPOST "http://localhost:8000/v1/query" -H 'Content-Type: application/json' -d '{"sql": "select version()",  "pagination": { "wait_time_secs": 10}}'
 


### PR DESCRIPTION
## Summary

- Add retry handling for Docker Compose image pulls in the integration test Makefile.
- Limit Docker Compose parallelism in CI integration jobs to reduce transient Docker Hub timeouts.

## Motivation

CI occasionally fails before tests start while pulling images from Docker Hub with errors such as `context deadline exceeded` and `Client.Timeout exceeded while awaiting headers`. Pulling the images separately with retries and reducing Compose concurrency should make these transient registry/network failures less likely without changing the test behavior.

## Testing

- `make -C tests -n up DATABEND_META_VERSION=v1.2.916-nightly DATABEND_QUERY_VERSION=v1.2.916-nightly`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/ci.yml .github/workflows/bindings.python.yml .github/workflows/bindings.nodejs.yml .github/workflows/cron.integration.yml`
