### PR TITLE
docs: clarify tenant param is only for Databend Cloud management mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,6 @@ Examples:
 
 | Arg               | Description                          |
 | ----------------- | ------------------------------------ |
-| `tenant`          | Tenant ID, Databend Cloud only.      |
 | `warehouse`       | Warehouse name, Databend Cloud only. |
 | `sslmode`         | Set to `disable` if not using tls.   |
 | `tls_ca_file`     | Custom root CA certificate path.     |

--- a/core/src/client.rs
+++ b/core/src/client.rs
@@ -112,6 +112,8 @@ pub struct APIClient {
 
     auth: Arc<dyn Auth>,
 
+    /// Tenant ID used only in Databend Cloud management mode.
+    /// This is NOT for specifying tenant in normal usage.
     tenant: Option<String>,
     warehouse: Mutex<Option<String>>,
     session_state: Mutex<SessionState>,
@@ -311,6 +313,8 @@ impl APIClient {
                     };
                     client.set_presign_mode(presign_mode);
                 }
+                // NOTE: `tenant` is only used in Databend Cloud management mode.
+                // It is not intended for daily use to specify a tenant.
                 "tenant" => {
                     client.tenant = Some(v.to_string());
                 }

--- a/driver/src/flight_sql.rs
+++ b/driver/src/flight_sql.rs
@@ -240,6 +240,8 @@ struct Args {
     user: String,
     password: SensitiveString,
     database: Option<String>,
+    /// Tenant ID used only in Databend Cloud management mode.
+    /// This is NOT for specifying tenant in normal usage.
     tenant: Option<String>,
     warehouse: Option<String>,
     tls: bool,
@@ -284,6 +286,8 @@ impl Args {
         let mut scheme = "https";
         for (k, v) in u.query_pairs() {
             match k.as_ref() {
+                // NOTE: `tenant` is only used in Databend Cloud management mode.
+                // It is not intended for daily use to specify a tenant.
                 "tenant" => args.tenant = Some(v.to_string()),
                 "warehouse" => args.warehouse = Some(v.to_string()),
                 "sslmode" => match v.as_ref() {


### PR DESCRIPTION
## Summary

Clarify that the `tenant` DSN parameter is only used in Databend Cloud management mode, not for specifying tenant in normal usage.

## Motivation

The `tenant` parameter in DSN/connection args can be confusing — users might think it's for daily use to specify a tenant. In reality, it's exclusively for Databend Cloud's internal management mode. This PR:

- Removes `tenant` from the user-facing DSN documentation in README.md (users shouldn't need it)
- Adds code comments in `core/src/client.rs` and `driver/src/flight_sql.rs` to make the intent clear for developers

## Testing

Documentation and comment-only change. Verified with `cargo check` — no build errors.
