### PR TITLE
fix: ignore pyo3 security advisories RUSTSEC-2026-0176/0177 in cargo-deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -3,11 +3,11 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
-    "RUSTSEC-2024-0370",
     "RUSTSEC-2024-0384",
     "RUSTSEC-2024-0436",
     "RUSTSEC-2025-0057",
-    "RUSTSEC-2025-0140",
+    "RUSTSEC-2026-0176",
+    "RUSTSEC-2026-0177",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary

Suppress pyo3 security advisories RUSTSEC-2026-0176 and RUSTSEC-2026-0177 in `cargo-deny`, and remove stale advisory ignores.

## Motivation

CI `cargo-deny` fails due to two pyo3 0.24 advisories:

- **RUSTSEC-2026-0176**: Out-of-bounds read in `nth`/`nth_back` for `PyList` and `PyTuple` iterators
- **RUSTSEC-2026-0177**: Missing `Sync` bound on `PyCFunction::new_closure` closures

The fix (pyo3 >= 0.29.0) drops Python 3.8 support. Since we want to keep cp38 compatibility, we ignore these advisories for now and keep pyo3 at 0.24.

Also removes stale ignores for RUSTSEC-2024-0370 and RUSTSEC-2025-0140 which no longer match any crate in the dependency tree (these were causing warnings in CI).

## Testing

- `cargo check --workspace` passes.
- `deny.toml` change only; no runtime behavior affected.
