### PR TITLE
docs: add PR title format rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ This repository is a Rust workspace for BendSQL plus a separate frontend, langua
 - Keep changes inside the owning subsystem unless the task clearly crosses boundaries.
 - Check for uncommitted user changes before editing and do not revert unrelated work.
 - Report the exact verification commands you ran, plus anything you skipped and why.
+- PR title must follow the Conventional Commits format validated by `amannn/action-semantic-pull-request@v5`.
+  Format: `type(scope): description` or `type: description`.
+  Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
 
 ## Task Routing
 


### PR DESCRIPTION
## Motivation

CI uses `amannn/action-semantic-pull-request@v5` to validate PR titles against the Conventional Commits format. This rule was not documented in `AGENTS.md`, which means AI agents (and new contributors) could create PRs with non-conforming titles and trigger CI failures.

## Changes

Added a PR title format rule to the Global Rules section of `AGENTS.md`:
- Must follow `type(scope): description` or `type: description`
- Lists all allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`

## Testing

Documentation-only change; no code affected. CI title check itself validates the PR title of this PR.
