### PR TITLE
fix(core): pin time below incompatible 0.3.52

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio-stream = "0.1"
 chrono = { version = "0.4.40", default-features = false, features = ["clock"] }
 chrono-tz = { version = "0.10.4" }
 jiff = { version = "0.2.10", features = ["tzdb-bundle-always"] }
+time = { version = ">=0.3.0, <0.3.52" }
 arrow = { version = "56" }
 arrow-array = { version = "56" }
 arrow-schema = { version = "56" }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -28,6 +28,7 @@ bytes = "1.10.1"
 base64 = "0.22.1"
 cookie = "0.18.1"
 jiff = { workspace = true }
+time = { workspace = true }
 log = { version = "0.4", features = ["kv"] }
 once_cell = "1.21"
 parking_lot = "0.12.3"

--- a/core/src/global_cookie_store.rs
+++ b/core/src/global_cookie_store.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use cookie::Cookie;
+use cookie::{Cookie, Expiration};
 use reqwest::cookie::CookieStore;
 use reqwest::header::HeaderValue;
 use std::collections::HashMap;
 use std::sync::RwLock;
+use time::OffsetDateTime;
 use url::Url;
 
 pub(crate) struct GlobalCookieStore {
@@ -31,6 +32,16 @@ impl GlobalCookieStore {
     }
 }
 
+fn is_expired(cookie: &Cookie<'_>) -> bool {
+    cookie
+        .max_age()
+        .is_some_and(|age| age <= time::Duration::ZERO)
+        || matches!(
+            cookie.expires(),
+            Some(Expiration::DateTime(expires)) if expires <= OffsetDateTime::now_utc()
+        )
+}
+
 impl CookieStore for GlobalCookieStore {
     fn set_cookies(&self, cookie_headers: &mut dyn Iterator<Item = &HeaderValue>, _url: &Url) {
         let iter = cookie_headers
@@ -39,12 +50,18 @@ impl CookieStore for GlobalCookieStore {
 
         let mut guard = self.cookies.write().unwrap();
         for cookie in iter {
-            guard.insert(cookie.name().to_string(), cookie);
+            let name = cookie.name().to_string();
+            if is_expired(&cookie) {
+                guard.remove(&name);
+            } else {
+                guard.insert(name, cookie);
+            }
         }
     }
 
     fn cookies(&self, _url: &Url) -> Option<HeaderValue> {
-        let guard = self.cookies.read().unwrap();
+        let mut guard = self.cookies.write().unwrap();
+        guard.retain(|_, cookie| !is_expired(cookie));
         let s: String = guard
             .values()
             .map(|cookie| cookie.name_value())


### PR DESCRIPTION
## Summary
- constrain the direct time dependency used with cookie 0.18.1 to versions below 0.3.52
- prevent Node.js binding CI from resolving the incompatible time parsing API change that breaks cookie compilation

## Verification
- cargo metadata --format-version 1 --manifest-path bindings/nodejs/Cargo.toml --locked --no-deps
- cd bindings/nodejs && pnpm prettier --check .

## Notes
- The failing CI job was build-nodejs in run 28484676819. Its log showed cookie 0.18.1 failing against time 0.3.52 with E0061 because time::parsing::Parsable::parse now requires a second defaults argument.
- Full local pnpm napi build / cargo build could not complete because local crates.io access repeatedly timed out while downloading the index.