### PR TITLE
chore: bump version to 0.34.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.34.0"
+version = "0.34.1"
 license = "Apache-2.0"
 authors = ["Databend Authors <opensource@databend.com>"]
 categories = ["database"]
@@ -22,10 +22,10 @@ keywords = ["databend", "database", "rust"]
 repository = "https://github.com/databendlabs/bendsql"
 
 [workspace.dependencies]
-databend-client = { path = "core", version = "0.34.0" }
-databend-driver = { path = "driver", version = "0.34.0" }
-databend-driver-core = { path = "sql", version = "0.34.0" }
-databend-driver-macros = { path = "macros", version = "0.34.0" }
+databend-client = { path = "core", version = "0.34.1" }
+databend-driver = { path = "driver", version = "0.34.1" }
+databend-driver-core = { path = "sql", version = "0.34.1" }
+databend-driver-macros = { path = "macros", version = "0.34.1" }
 
 jsonb = { version = "0.5.6" }
 tokio-stream = "0.1"

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-arm64",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-x64",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-arm64-gnu",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-arm64-musl",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-x64-gnu",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-x64-musl",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-win32-arm64-msvc",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "win32"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-win32-x64-msvc",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "os": [
     "win32"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "databend-driver",
   "author": "Databend Authors <opensource@databend.com>",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Summary

Bump version to 0.34.1.

## Changes

- `Cargo.toml`: workspace version and dependency versions
- `bindings/nodejs/package.json` and all platform-specific `package.json` files
