### PR TITLE
ci(bindings): restore nodejs windows builds

### DIFF
--- a/.github/workflows/bindings.nodejs.yml
+++ b/.github/workflows/bindings.nodejs.yml
@@ -12,13 +12,14 @@ jobs:
         uses: ./.github/actions/setup
         with:
           cache-key: bindings-nodejs-integration
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - name: Corepack
-        working-directory: bindings/nodejs
-        run: npm i -g --force corepack && corepack enable
       - name: Install dependencies
         working-directory: bindings/nodejs
         run: pnpm install
@@ -37,9 +38,8 @@ jobs:
           - { target: aarch64-unknown-linux-gnu, runner: ubuntu-22.04 }
           - { target: x86_64-unknown-linux-musl, runner: ubuntu-latest }
           - { target: aarch64-unknown-linux-musl, runner: ubuntu-latest }
-          # resolve it after: https://github.com/actions/setup-node/issues/1222
-          # - { target: x86_64-pc-windows-msvc, runner: windows-latest }
-          # - { target: aarch64-pc-windows-msvc, runner: windows-latest }
+          - { target: x86_64-pc-windows-msvc, runner: windows-latest }
+          - { target: aarch64-pc-windows-msvc, runner: windows-latest }
           - { target: x86_64-apple-darwin, runner: macos-latest }
           - { target: aarch64-apple-darwin, runner: macos-latest }
     steps:
@@ -49,6 +49,10 @@ jobs:
         with:
           cache-key: bindings-nodejs-${{ matrix.target }}
           target: ${{ matrix.target }}
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
       - name: Setup node
         uses: actions/setup-node@v4
         with:
@@ -58,9 +62,6 @@ jobs:
         uses: goto-bus-stop/setup-zig@v2
         with:
           version: 0.11.0
-      - name: Corepack
-        working-directory: bindings/nodejs
-        run: npm i -g --force corepack && corepack enable
       - name: Install dependencies
         working-directory: bindings/nodejs
         run: pnpm install
@@ -98,13 +99,14 @@ jobs:
         ver: ["18", "20", "22"]
     steps:
       - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.ver }}
-      - name: Corepack
-        working-directory: bindings/nodejs
-        run: npm i -g --force corepack && corepack enable
       - name: Install dependencies
         working-directory: bindings/nodejs
         run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,14 +289,15 @@ jobs:
       url: https://www.npmjs.com/package/databend-driver
     steps:
       - uses: actions/checkout@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.0
       - name: Setup node
         uses: actions/setup-node@v4
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"
-      - name: Corepack
-        working-directory: bindings/nodejs
-        run: npm i -g --force corepack && corepack enable
       - name: Install dependencies
         working-directory: bindings/nodejs
         run: pnpm install

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.34.1"
+version = "0.34.2"
 license = "Apache-2.0"
 authors = ["Databend Authors <opensource@databend.com>"]
 categories = ["database"]
@@ -22,10 +22,10 @@ keywords = ["databend", "database", "rust"]
 repository = "https://github.com/databendlabs/bendsql"
 
 [workspace.dependencies]
-databend-client = { path = "core", version = "0.34.1" }
-databend-driver = { path = "driver", version = "0.34.1" }
-databend-driver-core = { path = "sql", version = "0.34.1" }
-databend-driver-macros = { path = "macros", version = "0.34.1" }
+databend-client = { path = "core", version = "0.34.2" }
+databend-driver = { path = "driver", version = "0.34.2" }
+databend-driver-core = { path = "sql", version = "0.34.2" }
+databend-driver-macros = { path = "macros", version = "0.34.2" }
 
 jsonb = { version = "0.5.6" }
 tokio-stream = "0.1"

--- a/bindings/nodejs/npm/darwin-arm64/package.json
+++ b/bindings/nodejs/npm/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-arm64",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/darwin-x64/package.json
+++ b/bindings/nodejs/npm/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-darwin-x64",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "darwin"
   ],

--- a/bindings/nodejs/npm/linux-arm64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-arm64-gnu",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-arm64-musl/package.json
+++ b/bindings/nodejs/npm/linux-arm64-musl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-arm64-musl",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-x64-gnu/package.json
+++ b/bindings/nodejs/npm/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-x64-gnu",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/linux-x64-musl/package.json
+++ b/bindings/nodejs/npm/linux-x64-musl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-linux-x64-musl",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "linux"
   ],

--- a/bindings/nodejs/npm/win32-arm64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-arm64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-win32-arm64-msvc",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "win32"
   ],

--- a/bindings/nodejs/npm/win32-x64-msvc/package.json
+++ b/bindings/nodejs/npm/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@databend-driver/lib-win32-x64-msvc",
   "repository": "https://github.com/databendlabs/bendsql.git",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "os": [
     "win32"
   ],

--- a/bindings/nodejs/package.json
+++ b/bindings/nodejs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "databend-driver",
   "author": "Databend Authors <opensource@databend.com>",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
## Motivation

`databend-driver` declares Windows native packages in its NAPI target list, but the Node.js binding workflow was not building the `win32-msvc` artifacts. That allowed the main npm package to reference optional Windows packages that were never published, which breaks Yarn Classic dependency resolution even on non-Windows platforms.

The previous Windows matrix was disabled due to a Corepack/setup-node issue. This change avoids Corepack for the Node.js binding workflows by using `pnpm/action-setup`, then restores the Windows build targets so the npm release can include the declared Windows packages.

## Summary

- Replace Corepack setup with `pnpm/action-setup@v4` in Node.js binding CI and npm publishing.
- Restore `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc` Node.js binding build targets.
- Bump the workspace and Node.js package versions to `0.34.2` so the release workflow publishes a complete package graph.

## Testing

- `git diff --check`
- Node.js binding workflow should build Linux, macOS, and Windows artifacts in CI.
