### PR TITLE
fix(python): correct cursor rowcount semantics

### DIFF
--- a/bindings/python/src/blocking.rs
+++ b/bindings/python/src/blocking.rs
@@ -253,6 +253,7 @@ pub struct BlockingDatabendCursor {
     conn: Arc<databend_driver::Connection>,
     rows: Option<Arc<Mutex<databend_driver::RowIterator>>>,
     stats: Arc<RwLock<Option<databend_driver::ServerStats>>>,
+    rowcount_mode: RowcountMode,
     // buffer is used to store only the first row after execute
     buffer: Vec<Row>,
     schema: Option<SchemaRef>,
@@ -265,6 +266,7 @@ impl BlockingDatabendCursor {
             conn: Arc::new(conn),
             rows: None,
             stats: Arc::new(RwLock::new(None)),
+            rowcount_mode: RowcountMode::Unknown,
             buffer: Vec::new(),
             schema: None,
             closed: false,
@@ -276,8 +278,25 @@ impl BlockingDatabendCursor {
     fn reset(&mut self) {
         self.rows = None;
         *self.stats.write().unwrap() = None;
+        self.rowcount_mode = RowcountMode::Unknown;
         self.buffer.clear();
         self.schema = None;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum RowcountMode {
+    #[default]
+    Unknown,
+    Affected,
+}
+
+impl RowcountMode {
+    fn rowcount(self, stats: Option<&databend_driver::ServerStats>) -> i64 {
+        match self {
+            RowcountMode::Affected => stats.map(|stats| stats.write_rows as i64).unwrap_or(-1),
+            RowcountMode::Unknown => -1,
+        }
     }
 }
 
@@ -333,12 +352,8 @@ impl BlockingDatabendCursor {
 
     #[getter]
     pub fn rowcount(&self, _py: Python) -> i64 {
-        self.stats
-            .read()
-            .unwrap()
-            .as_ref()
-            .map(|stats| stats.write_rows as i64)
-            .unwrap_or(-1)
+        self.rowcount_mode
+            .rowcount(self.stats.read().unwrap().as_ref())
     }
 
     #[getter]
@@ -380,17 +395,24 @@ impl BlockingDatabendCursor {
         // fetch first row after execute
         // then we could finish the query directly if there's no result
         let params = to_sql_params(params);
-        let (first, rows) = wait_for_future(py, async move {
-            let rows = if params.is_empty() {
-                conn.query_iter_ext(&operation).await?
+        let (rowcount_mode, first, rows) = wait_for_future(py, async move {
+            let query = conn.query(&operation);
+            let rowcount_mode = if query.is_dml() {
+                RowcountMode::Affected
             } else {
-                conn.query(&operation).bind(params).iter_ext().await?
+                RowcountMode::Unknown
+            };
+            let rows = if params.is_empty() {
+                query.iter_ext().await?
+            } else {
+                query.bind(params).iter_ext().await?
             };
             let mut rows = capture_stats(rows, cursor_stats);
             let first = rows.next().await.transpose()?;
-            Ok::<_, databend_driver::Error>((first, rows))
+            Ok::<_, databend_driver::Error>((rowcount_mode, first, rows))
         })
         .map_err(DriverError::new)?;
+        self.rowcount_mode = rowcount_mode;
         if let Some(first) = first {
             self.buffer.push(Row::new(first));
         }
@@ -408,6 +430,7 @@ impl BlockingDatabendCursor {
         seq_of_parameters: Vec<Bound<'p, PyAny>>,
     ) -> PyResult<PyObject> {
         self.reset();
+        self.rowcount_mode = RowcountMode::Affected;
         let conn = self.conn.clone();
         if let Some(param) = seq_of_parameters.first() {
             if param.downcast::<PyList>().is_ok() || param.downcast::<PyTuple>().is_ok() {
@@ -600,5 +623,22 @@ mod tests {
         assert!(rows.next().await.transpose().unwrap().is_some());
         assert!(rows.next().await.transpose().unwrap().is_none());
         assert_eq!(stats.read().unwrap().as_ref().unwrap().write_rows, 2);
+    }
+
+    #[test]
+    fn test_rowcount_mode() {
+        let zero = ServerStats {
+            write_rows: 0,
+            ..Default::default()
+        };
+        let positive = ServerStats {
+            write_rows: 3,
+            ..Default::default()
+        };
+
+        assert_eq!(RowcountMode::Unknown.rowcount(Some(&zero)), -1);
+        assert_eq!(RowcountMode::Affected.rowcount(None), -1);
+        assert_eq!(RowcountMode::Affected.rowcount(Some(&zero)), 0);
+        assert_eq!(RowcountMode::Affected.rowcount(Some(&positive)), 3);
     }
 }

--- a/bindings/python/tests/cursor/steps/binding.py
+++ b/bindings/python/tests/cursor/steps/binding.py
@@ -248,11 +248,12 @@ def _(context):
 
     # fetchall
     context.cursor.execute("SELECT * FROM test")
-    assert context.cursor.rowcount == 0
+    assert context.cursor.rowcount == -1
     assert context.cursor.stats.write_rows == 0
     rows = context.cursor.fetchall()
     ret = [row.values() for row in rows]
     assert ret == expected, f"ret: {ret}"
+    assert context.cursor.rowcount == -1
 
     desc = context.cursor.description
     assert desc is not None
@@ -271,6 +272,10 @@ def _(context):
     context.cursor.execute("UPDATE test SET s = s")
     assert context.cursor.rowcount == 3
     assert context.cursor.stats.write_rows == 3
+
+    context.cursor.execute("UPDATE test SET s = s WHERE false")
+    assert context.cursor.rowcount == 0
+    assert context.cursor.stats.write_rows == 0
 
     context.cursor.execute(
         r"""

--- a/core/src/pages.rs
+++ b/core/src/pages.rs
@@ -115,6 +115,9 @@ impl Pages {
         mut self,
         need_progress: bool,
     ) -> Result<(Self, Schema, ResultFormatSettings)> {
+        // A successful zero-row statement can have neither schema nor non-zero
+        // progress, but its final page still contains meaningful server stats.
+        let mut pending_page: Option<Page> = None;
         while let Some(page) = self.next().await {
             let page = page?;
             if !page.raw_schema.is_empty()
@@ -147,8 +150,72 @@ impl Pages {
                 }
                 return Ok((self, schema, settings));
             }
+            if need_progress {
+                if let Some(pending) = pending_page.as_mut() {
+                    pending.update(page);
+                } else {
+                    pending_page = Some(page);
+                }
+            }
+        }
+        if let Some(page) = pending_page {
+            let settings = ResultFormatSettings::try_from(&page.settings)?;
+            self.add_back(page);
+            return Ok((self, Schema::default(), settings));
         }
         Ok((self, Schema::default(), ResultFormatSettings::default()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn wait_for_schema_preserves_zero_progress_page() {
+        let client = APIClient::new(
+            "databend://root:@localhost:8000/default?sslmode=disable&login=disable",
+            None,
+        )
+        .await
+        .unwrap();
+        let response: QueryResponse = serde_json::from_str(
+            r#"{
+                "id":"query-id",
+                "node_id":null,
+                "session_id":null,
+                "session":null,
+                "schema":[],
+                "data":[],
+                "state":"Succeeded",
+                "settings":null,
+                "error":null,
+                "warnings":null,
+                "stats":{
+                    "scan_progress":{"rows":0,"bytes":0},
+                    "write_progress":{"rows":0,"bytes":0},
+                    "result_progress":{"rows":0,"bytes":0},
+                    "spill_progress":{"file_nums":0,"bytes":0},
+                    "running_time_ms":1.0,
+                    "total_scan":null
+                },
+                "result_timeout_secs":null,
+                "stats_uri":null,
+                "final_uri":null,
+                "next_uri":null,
+                "kill_uri":null
+            }"#,
+        )
+        .unwrap();
+        let pages = Pages::new(client, response, vec![], true).unwrap();
+
+        let (mut pages, schema, _) = pages.wait_for_schema(true).await.unwrap();
+        let page = pages.next().await.unwrap().unwrap();
+
+        assert!(schema.fields().is_empty());
+        assert_eq!(page.stats.progresses.write_progress.rows, 0);
+        assert_eq!(page.stats.running_time_ms, 1.0);
+        assert!(pages.next().await.is_none());
     }
 }
 

--- a/driver/src/client.rs
+++ b/driver/src/client.rs
@@ -14,6 +14,7 @@
 
 use log::error;
 use once_cell::sync::Lazy;
+use std::cell::OnceCell;
 use std::collections::BTreeMap;
 use std::path::Path;
 use std::str::FromStr;
@@ -22,12 +23,13 @@ use url::Url;
 use crate::conn::IConnection;
 #[cfg(feature = "flight-sql")]
 use crate::flight_sql::FlightSQLConnection;
+use crate::params::parse_statement;
 use crate::placeholder::PlaceholderVisitor;
 use crate::ConnectionInfo;
 use crate::Params;
 
 use databend_client::PresignedResponse;
-use databend_common_ast::parser::Dialect;
+use databend_common_ast::ast::Statement;
 use databend_driver_core::error::{Error, Result};
 use databend_driver_core::raw_rows::{RawRow, RawRowIterator};
 use databend_driver_core::rows::{Row, RowIterator, RowStatsIterator, ServerStats};
@@ -45,6 +47,22 @@ static VERSION: Lazy<String> = Lazy::new(|| {
 pub enum LoadMethod {
     Stage,
     Streaming,
+}
+
+fn statement_is_dml(statement: Option<&Statement>) -> bool {
+    match statement {
+        Some(Statement::StatementWithSettings { stmt, .. }) => statement_is_dml(Some(stmt)),
+        Some(
+            Statement::Insert(_)
+            | Statement::InsertMultiTable(_)
+            | Statement::Replace(_)
+            | Statement::MergeInto(_)
+            | Statement::Delete(_)
+            | Statement::Update(_)
+            | Statement::CopyIntoTable(_),
+        ) => true,
+        _ => false,
+    }
 }
 
 impl FromStr for LoadMethod {
@@ -434,6 +452,7 @@ pub struct QueryBuilder<'a> {
     connection: &'a Connection,
     sql: String,
     params: Option<Params>,
+    statement: OnceCell<Option<Statement>>,
 }
 
 impl<'a> QueryBuilder<'a> {
@@ -442,12 +461,17 @@ impl<'a> QueryBuilder<'a> {
             connection,
             sql: sql.to_string(),
             params: None,
+            statement: OnceCell::new(),
         }
     }
 
     pub fn bind<P: Into<Params> + Send>(mut self, params: P) -> Self {
         self.params = Some(params.into());
         self
+    }
+
+    pub fn is_dml(&self) -> bool {
+        statement_is_dml(self.statement())
     }
 
     pub async fn iter(self) -> Result<RowIterator> {
@@ -532,14 +556,20 @@ impl<'a> QueryBuilder<'a> {
 
     fn should_use_server_side_params(&self) -> bool {
         self.connection.inner.supports_server_side_params()
-            && !sql_has_dollar_placeholders(&self.sql)
+            && !statement_has_dollar_placeholders(self.statement())
     }
 
     fn get_final_sql(&self) -> String {
         match &self.params {
-            Some(params) => params.replace(&self.sql),
+            Some(params) => params.replace_with_statement(&self.sql, self.statement()),
             None => self.sql.clone(),
         }
+    }
+
+    fn statement(&self) -> Option<&Statement> {
+        self.statement
+            .get_or_init(|| parse_statement(&self.sql))
+            .as_ref()
     }
 }
 
@@ -548,6 +578,7 @@ pub struct ExecBuilder<'a> {
     connection: &'a Connection,
     sql: String,
     params: Option<Params>,
+    statement: OnceCell<Option<Statement>>,
 }
 
 impl<'a> ExecBuilder<'a> {
@@ -556,6 +587,7 @@ impl<'a> ExecBuilder<'a> {
             connection,
             sql: sql.to_string(),
             params: None,
+            statement: OnceCell::new(),
         }
     }
 
@@ -575,16 +607,26 @@ impl<'a> ExecBuilder<'a> {
                     .await;
             }
         }
-        let sql = match self.params {
-            Some(params) => params.replace(&self.sql),
-            None => self.sql,
-        };
+        let sql = self.get_final_sql();
         self.connection.inner.exec(&sql).await
     }
 
     fn should_use_server_side_params(&self) -> bool {
         self.connection.inner.supports_server_side_params()
-            && !sql_has_dollar_placeholders(&self.sql)
+            && !statement_has_dollar_placeholders(self.statement())
+    }
+
+    fn get_final_sql(&self) -> String {
+        match &self.params {
+            Some(params) => params.replace_with_statement(&self.sql, self.statement()),
+            None => self.sql.clone(),
+        }
+    }
+
+    fn statement(&self) -> Option<&Statement> {
+        self.statement
+            .get_or_init(|| parse_statement(&self.sql))
+            .as_ref()
     }
 }
 
@@ -598,14 +640,10 @@ impl<'a> std::future::IntoFuture for ExecBuilder<'a> {
     }
 }
 
-fn sql_has_dollar_placeholders(sql: &str) -> bool {
-    let tokens = match databend_common_ast::parser::tokenize_sql(sql) {
-        Ok(t) => t,
-        Err(_) => return false,
-    };
-    if let Ok((stmt, _)) = databend_common_ast::parser::parse_sql(&tokens, Dialect::PostgreSQL) {
+fn statement_has_dollar_placeholders(statement: Option<&Statement>) -> bool {
+    if let Some(statement) = statement {
         let mut visitor = PlaceholderVisitor::new();
-        return visitor.has_dollar_positions(&stmt);
+        return visitor.has_dollar_positions(statement);
     }
     false
 }
@@ -616,4 +654,20 @@ pub trait RowORM: TryFrom<Row> + Clone {
     fn query_field_names() -> Vec<&'static str>; // For SELECT queries (exclude skip_deserializing)
     fn insert_field_names() -> Vec<&'static str>; // For INSERT statements (exclude skip_serializing)
     fn to_values(&self) -> Vec<Value>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_statement_is_dml() {
+        let insert = parse_statement("INSERT INTO t VALUES (1)");
+        let update = parse_statement("SETTINGS(max_threads = 1) UPDATE t SET a = 1");
+        let query = parse_statement("SELECT * FROM t");
+
+        assert!(statement_is_dml(insert.as_ref()));
+        assert!(statement_is_dml(update.as_ref()));
+        assert!(!statement_is_dml(query.as_ref()));
+    }
 }

--- a/driver/src/params.rs
+++ b/driver/src/params.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::fmt::Debug;
 
+use databend_common_ast::ast::Statement;
 use databend_common_ast::parser::Dialect;
 
 pub trait Param: Debug {
@@ -126,17 +127,34 @@ impl Params {
     }
 
     pub fn replace(&self, sql: &str) -> String {
-        if !self.is_empty() {
-            let tokens = databend_common_ast::parser::tokenize_sql(sql).unwrap();
-            if let Ok((stmt, _)) =
-                databend_common_ast::parser::parse_sql(&tokens, Dialect::PostgreSQL)
-            {
-                let mut v = super::placeholder::PlaceholderVisitor::new();
-                return v.replace_sql(self, &stmt, sql);
-            }
+        if self.is_empty() {
+            return sql.to_string();
         }
-        sql.to_string()
+        let statement = parse_statement(sql);
+        self.replace_with_statement(sql, statement.as_ref())
     }
+
+    pub(crate) fn replace_with_statement(
+        &self,
+        sql: &str,
+        statement: Option<&Statement>,
+    ) -> String {
+        if self.is_empty() {
+            return sql.to_string();
+        }
+        let Some(statement) = statement else {
+            return sql.to_string();
+        };
+        let mut visitor = super::placeholder::PlaceholderVisitor::new();
+        visitor.replace_sql(self, statement, sql)
+    }
+}
+
+pub(crate) fn parse_statement(sql: &str) -> Option<Statement> {
+    let tokens = databend_common_ast::parser::tokenize_sql(sql).ok()?;
+    let (statement, _) =
+        databend_common_ast::parser::parse_sql(&tokens, Dialect::PostgreSQL).ok()?;
+    Some(statement)
 }
 
 // Implement Param for numeric types that fit in serde_json::Number
@@ -475,6 +493,9 @@ mod tests {
         let sql =
             "SELECT * FROM table WHERE a = ? AND '?' = cj AND b = ? AND c = ? AND d = ? AND e = ? AND f = ?";
         let replaced_sql = params.replace(sql);
+        assert_eq!(replaced_sql, "SELECT * FROM table WHERE a = 1 AND '?' = cj AND b = '44' AND c = 2 AND d = 3 AND e = '55' AND f = '66'");
+        let statement = parse_statement(sql);
+        let replaced_sql = params.replace_with_statement(sql, statement.as_ref());
         assert_eq!(replaced_sql, "SELECT * FROM table WHERE a = 1 AND '?' = cj AND b = '44' AND c = 2 AND d = 3 AND e = '55' AND f = '66'");
 
         let params = params! {a => 1, b => "44", c => 2, d => 3, e => "55", f => "66"};


### PR DESCRIPTION
## Summary

- keep `rowcount` at `-1` for result-producing and unclassified statements
- continue reporting `write_rows` for DML, including statements that affect zero rows
- preserve zero-progress REST pages so successful empty writes still expose `ServerStats`
- cache the parsed SQL AST in driver query builders and reuse it for DML classification, placeholder detection, and parameter replacement

## Motivation

The target branch exposes `write_rows` as `cursor.rowcount`, but that makes a non-empty `SELECT` report `0`. It also misses successful statements whose final response has no schema, rows, or non-zero progress, leaving zero-row DML with `stats is None` and `rowcount == -1`.

This follow-up keeps the write-statistics behavior for DML while making result-set row counts conform to PEP 249 and retaining zero-valued final statistics. SQL classification reuses the driver's existing parser result instead of parsing again in the Python binding.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p databend-client --lib`
- `cargo test -p databend-driver --lib`
- `cargo test -p databend-python --lib`
- `cargo check -p databend-python`
- `cargo clippy -p databend-client -p databend-driver -p databend-python --lib -- -D warnings`
- `cd bindings/python && uv run ruff format --check package/databend_driver/__init__.pyi tests/cursor/steps/binding.py`
- `make integration-bindings-python`
- `cd bindings/python && QUERY_RESULT_FORMAT=arrow .venv/bin/python -m behave tests/cursor --name 'Insert and Select'`
- `git diff --check`

## Compatibility

For a result-producing statement, `cursor.rowcount` remains `-1`. DML continues to report affected rows immediately from server statistics.

Follow-up to #791.
